### PR TITLE
move tika stream into try-with

### DIFF
--- a/src/main/java/org/fcrepo/migration/PicocliMigrator.java
+++ b/src/main/java/org/fcrepo/migration/PicocliMigrator.java
@@ -56,7 +56,7 @@ import static picocli.CommandLine.Help.Visibility.ALWAYS;
  * @since 2019-11-15
  */
 @Command(name = "migration-utils", mixinStandardHelpOptions = true, sortOptions = false,
-        version = "Migration Utils - 4.4.1")
+        version = "Migration Utils - 4.4.1.a")
 public class PicocliMigrator implements Callable<Integer> {
 
     private static final Logger LOGGER = getLogger(PicocliMigrator.class);

--- a/src/main/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandler.java
+++ b/src/main/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandler.java
@@ -303,8 +303,8 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
         if (Strings.isNullOrEmpty(mime)) {
             final var meta = new Metadata();
             meta.set(Metadata.RESOURCE_NAME_KEY, dv.getDatastreamInfo().getDatastreamId());
-            try (var content = dv.getContent()) {
-                mime = mimeDetector.detect(TikaInputStream.get(content), meta).toString();
+            try (var content = TikaInputStream.get(dv.getContent())) {
+                mime = mimeDetector.detect(content, meta).toString();
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }


### PR DESCRIPTION
**JIRA Ticket**: none

# What does this Pull Request do?

Calvin is still having issues with running out of file descriptors. I cannot reproduce the issue locally, so this is another attempt at fixing the problem. I suspect that Tika maybe creating some additional resources that were not being closed. Tika is only used when a datastream's media type is not already known, which could be why I'm having trouble reproducing the problem with my datasets.

# Interested parties
@fcrepo/committers
