### PR TITLE
close resources when they are skipped

### DIFF
--- a/src/main/java/org/fcrepo/migration/FedoraObjectProcessor.java
+++ b/src/main/java/org/fcrepo/migration/FedoraObjectProcessor.java
@@ -23,7 +23,7 @@ import javax.xml.stream.XMLStreamException;
  * StreamingFedoraObjectHandler.
  * @author mdurbin
  */
-public interface FedoraObjectProcessor {
+public interface FedoraObjectProcessor extends AutoCloseable {
 
     /**
      * get object information.
@@ -37,4 +37,10 @@ public interface FedoraObjectProcessor {
      * @throws XMLStreamException xml stream exception
      */
     public void processObject(StreamingFedoraObjectHandler handler) throws XMLStreamException;
+
+    /**
+     * Close resources associated to the processor
+     */
+    void close();
+
 }

--- a/src/main/java/org/fcrepo/migration/Migrator.java
+++ b/src/main/java/org/fcrepo/migration/Migrator.java
@@ -15,18 +15,20 @@
  */
 package org.fcrepo.migration;
 
-import static org.slf4j.LoggerFactory.getLogger;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.List;
-import javax.xml.stream.XMLStreamException;
 import org.fcrepo.migration.pidlist.PidListManager;
 import org.slf4j.Logger;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.FileSystemXmlApplicationContext;
 import org.springframework.core.io.ClassPathResource;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.List;
+
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * A class that represents a command-line program to migrate a fedora 3
@@ -144,8 +146,7 @@ public class Migrator {
         int index = 0;
 
         for (final var iterator = source.iterator(); iterator.hasNext();) {
-            try {
-                final var o = iterator.next();
+            try (final var o = iterator.next()) {
                 final String pid = o.getObjectInfo().getPid();
                 if (pid != null) {
                     // Process if limit is '-1', or we have not hit the non-negative 'limit'...

--- a/src/main/java/org/fcrepo/migration/PicocliMigrator.java
+++ b/src/main/java/org/fcrepo/migration/PicocliMigrator.java
@@ -56,7 +56,7 @@ import static picocli.CommandLine.Help.Visibility.ALWAYS;
  * @since 2019-11-15
  */
 @Command(name = "migration-utils", mixinStandardHelpOptions = true, sortOptions = false,
-        version = "Migration Utils - 4.4.1.a")
+        version = "Migration Utils - 4.4.1.b")
 public class PicocliMigrator implements Callable<Integer> {
 
     private static final Logger LOGGER = getLogger(PicocliMigrator.class);

--- a/src/main/java/org/fcrepo/migration/foxml/FoxmlInputStreamFedoraObjectProcessor.java
+++ b/src/main/java/org/fcrepo/migration/foxml/FoxmlInputStreamFedoraObjectProcessor.java
@@ -169,16 +169,23 @@ public class FoxmlInputStreamFedoraObjectProcessor implements FedoraObjectProces
             cleanUpTempFiles();
             throw new RuntimeException(e);
         } finally {
-            try {
-                reader.close();
-            } catch (final XMLStreamException e) {
-                LOG.warn("Failed to close reader cleanly", e);
-            }
-            try {
-                stream.close();
-            } catch (IOException e) {
-                LOG.warn("Failed to close file cleanly", e);
-            }
+            close();
+        }
+    }
+
+    /**
+     * Close resources associated to the processor
+     */
+    public void close() {
+        try {
+            reader.close();
+        } catch (final XMLStreamException e) {
+            LOG.warn("Failed to close reader cleanly", e);
+        }
+        try {
+            stream.close();
+        } catch (IOException e) {
+            LOG.warn("Failed to close file cleanly", e);
         }
     }
 


### PR DESCRIPTION
**JIRA Ticket**: none

# What does this Pull Request do?

If you're using the resume functionality or a pid list then some objects are skipped. Before this change, the skipped objects did not have their associated resources closed. This change closes those resources.

# How should this be tested?

Run the tooling with a pid list that excludes a large number of objects and you should not run out of file descriptors.

# Interested parties
@fcrepo/committers
