### PR TITLE
cleanup object processor state on exception

### DIFF
--- a/src/main/java/org/fcrepo/migration/foxml/FoxmlInputStreamFedoraObjectProcessor.java
+++ b/src/main/java/org/fcrepo/migration/foxml/FoxmlInputStreamFedoraObjectProcessor.java
@@ -164,11 +164,14 @@ public class FoxmlInputStreamFedoraObjectProcessor implements FedoraObjectProces
                 reader.next();
             }
 
-        } catch (XMLStreamException | JAXBException e) {
+        } catch (Exception e) {
             handler.abortObject(objectInfo);
-            cleanUpTempFiles();
+            if (e instanceof RuntimeException) {
+                throw (RuntimeException) e;
+            }
             throw new RuntimeException(e);
         } finally {
+            cleanUpTempFiles();
             close();
         }
     }
@@ -191,7 +194,9 @@ public class FoxmlInputStreamFedoraObjectProcessor implements FedoraObjectProces
 
     private void cleanUpTempFiles() {
         for (final File f : this.tempFiles) {
-            f.delete();
+            if (f.exists()) {
+                f.delete();
+            }
         }
     }
 

--- a/src/main/java/org/fcrepo/migration/handlers/ObjectAbstractionStreamingFedoraObjectHandler.java
+++ b/src/main/java/org/fcrepo/migration/handlers/ObjectAbstractionStreamingFedoraObjectHandler.java
@@ -86,33 +86,36 @@ public class ObjectAbstractionStreamingFedoraObjectHandler implements StreamingF
 
     @Override
     public void completeObject(final ObjectInfo object) {
-        handler.processObject(new ObjectReference() {
-            @Override
-            public ObjectInfo getObjectInfo() {
-                return objectInfo;
-            }
+        try {
+            handler.processObject(new ObjectReference() {
+                @Override
+                public ObjectInfo getObjectInfo() {
+                    return objectInfo;
+                }
 
-            @Override
-            public ObjectProperties getObjectProperties() {
-                return objectProperties;
-            }
+                @Override
+                public ObjectProperties getObjectProperties() {
+                    return objectProperties;
+                }
 
-            @Override
-            public List<String> listDatastreamIds() {
-                return dsIds;
-            }
+                @Override
+                public List<String> listDatastreamIds() {
+                    return dsIds;
+                }
 
-            @Override
-            public List<DatastreamVersion> getDatastreamVersions(final String datastreamId) {
-                return dsIdToVersionListMap.get(datastreamId);
-            }
+                @Override
+                public List<DatastreamVersion> getDatastreamVersions(final String datastreamId) {
+                    return dsIdToVersionListMap.get(datastreamId);
+                }
 
-            @Override
-            public boolean hadFedora2Disseminators() {
-                return disseminatorsSkipped > 0;
-            }
-        });
-        cleanForReuse();
+                @Override
+                public boolean hadFedora2Disseminators() {
+                    return disseminatorsSkipped > 0;
+                }
+            });
+        } finally {
+            cleanForReuse();
+        }
     }
 
     @Override


### PR DESCRIPTION
# What does this Pull Request do?

This should hopefully fix the problems @sprater experienced while trying to migrate objects with errors. It should reset the object handler's state on exception. The state management here is less than ideal, so it's possible there may be a few more surprises left to find.

# How should this be tested?

@sprater should run the PR and confirm it works.

# Interested parties
@fcrepo/committers, @sprater 
