### PR TITLE
Fcrepo 3460:  Improve processing with --continue-on-error

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ General usage of the migration utils CLI is as follows:
 
 The following CLI options for specifying details of a given migration are available:
 ```
-Usage: migration-utils [-hrVx] [--debug] -a=<targetDir> [-d=<f3DatastreamsDir>]
-                       [-e=<f3ExportedDir>] [-f=<f3hostname>] [-i=<indexDir>]
-                       [-l=<objectLimit>] [-o=<f3ObjectsDir>] [-p=<pidFile>]
-                       -t=<f3SourceType> [-y=<ocflLayout>]
+Usage: migration-utils [-chrVx] [--debug] -a=<targetDir>
+                       [-d=<f3DatastreamsDir>] [-e=<f3ExportedDir>]
+                       [-f=<f3hostname>] [-i=<indexDir>] [-l=<objectLimit>]
+                       [-m=<migrationType>] [-o=<f3ObjectsDir>] [-p=<pidFile>]
+                       -t=<f3SourceType> [-u=<user>] [-U=<userUri>]
   -h, --help                 Show this help message and exit.
   -V, --version              Print version information and exit.
   -t, --source-type=<f3SourceType>
@@ -70,13 +71,17 @@ Usage: migration-utils [-hrVx] [--debug] -a=<targetDir> [-d=<f3DatastreamsDir>]
   -a, --target-dir=<targetDir>
                              Directory where OCFL storage root and supporting
                                state will be written
-  -m, --migration-type=<migrationType>  Type of OCFL objects to migrate to. Choices: 
+  -m, --migration-type=<migrationType>
+                             Type of OCFL objects to migrate to. Choices:
                                FEDORA_OCFL | PLAIN_OCFL
                                Default: FEDORA_OCFL
   -l, --limit=<objectLimit>  Limit number of objects to be processed.
                                Default: no limit
   -r, --resume               Resume from last successfully migrated Fedora 3
                                object
+                               Default: false
+  -c, --continue-on-error    Continue to next PID if an error occurs (instead
+                               of exiting). Disabled by default.
                                Default: false
   -p, --pid-file=<pidFile>   PID file listing which Fedora 3 objects to migrate
   -i, --index-dir=<indexDir> Directory where cached index of datastreams (will
@@ -88,11 +93,11 @@ Usage: migration-utils [-hrVx] [--debug] -a=<targetDir> [-d=<f3DatastreamsDir>]
                              Hostname of Fedora 3, used for replacing
                                placeholder in 'E' and 'R' datastream URLs
                                Default: fedora.info
-  -u, --username=<username>
-                             The username to associate with all of the migrated resources.
+  -u, --username=<user>      The username to associate with all of the migrated
+                               resources.
                                Default: fedoraAdmin
-  -U, --user-uri=<uri>
-                             The URI associated with the username
+  -U, --user-uri=<userUri>   The username to associate with all of the migrated
+                               resources.
                                Default: info:fedora/fedoraAdmin
       --debug                Enables debug logging
 ```

--- a/src/main/java/org/fcrepo/migration/Migrator.java
+++ b/src/main/java/org/fcrepo/migration/Migrator.java
@@ -133,7 +133,8 @@ public class Migrator {
      *
      * @param maxErrors the maximum number of errors.
      */
-    public void setMaxErrors(final int maxErrors) { this.maxErrors = maxErrors; }
+    public void setMaxErrors(final int maxErrors) {
+        this.maxErrors = maxErrors; }
 
     /**
      * The constructor for migrator.
@@ -171,7 +172,8 @@ public class Migrator {
                             if (this.continueOnError) {
                                 numErrors++;
                                 if (maxErrors > 0 && numErrors > maxErrors) {
-                                    LOGGER.error("Maximum number of sequential errors reached: {}.  Exiting.", maxErrors);
+                                    LOGGER.error("Maximum number of sequential errors reached: {}.  Exiting.",
+                                            maxErrors);
                                     throw new RuntimeException(ex);
                                 }
                                 continue;

--- a/src/main/java/org/fcrepo/migration/Migrator.java
+++ b/src/main/java/org/fcrepo/migration/Migrator.java
@@ -76,8 +76,6 @@ public class Migrator {
 
     private boolean continueOnError;
 
-    private int maxErrors;
-
     /**
      * the migrator. set limit to -1.
      */
@@ -129,14 +127,6 @@ public class Migrator {
     }
 
     /**
-     * set the maximum number of sequential errors to skip before exiting
-     *
-     * @param maxErrors the maximum number of errors.
-     */
-    public void setMaxErrors(final int maxErrors) {
-        this.maxErrors = maxErrors; }
-
-    /**
      * The constructor for migrator.
      * @param source the source
      * @param handler the handler
@@ -154,7 +144,6 @@ public class Migrator {
      */
     public void run() throws XMLStreamException {
         int index = 0;
-        int numErrors = 0;
 
         for (final var iterator = source.iterator(); iterator.hasNext();) {
             try (final var o = iterator.next()) {
@@ -166,16 +155,9 @@ public class Migrator {
                         LOGGER.info("Processing \"" + pid + "\"...");
                         try {
                             o.processObject(handler);
-                            numErrors = 0;
                         } catch (Exception ex) {
                             LOGGER.error("MIGRATION_FAILURE: pid=\"{}\", message=\"{}\"", pid, ex.getMessage(), ex);
                             if (this.continueOnError) {
-                                numErrors++;
-                                if (maxErrors > 0 && numErrors > maxErrors) {
-                                    LOGGER.error("Maximum number of sequential errors reached: {}.  Exiting.",
-                                            maxErrors);
-                                    throw new RuntimeException(ex);
-                                }
                                 continue;
                             } else {
                                 throw new RuntimeException(ex);
@@ -187,11 +169,6 @@ public class Migrator {
             } catch (Exception ex) {
                 if (this.continueOnError) {
                     LOGGER.error("MIGRATION_FAILURE: UNREADABLE_OBJECT: message=\"{}\"", ex.getMessage(), ex);
-                    numErrors++;
-                    if (maxErrors > 0 && numErrors > maxErrors) {
-                        LOGGER.error("Maximum number of sequential errors reached: {}.  Exiting.", maxErrors);
-                        throw new RuntimeException(ex);
-                    }
                     continue;
                 } else {
                     throw new RuntimeException(ex);

--- a/src/main/java/org/fcrepo/migration/PicocliMigrator.java
+++ b/src/main/java/org/fcrepo/migration/PicocliMigrator.java
@@ -105,11 +105,6 @@ public class PicocliMigrator implements Callable<Integer> {
             description = "Continue to next PID if an error occurs (instead of exiting). Disabled by default.")
     private boolean continueOnError;
 
-    @Option(names = {"--max-errors", "-M"}, defaultValue = "0", showDefaultValue = ALWAYS, order = 23,
-            description = "Maximum number of errors in a row to skip before exiting. " +
-                    "Used in conjunction with --continue-on-error.  Default: no maximum")
-    private int maxErrors;
-
     @Option(names = {"--pid-file", "-p"}, order = 24,
             description = "PID file listing which Fedora 3 objects to migrate")
     private File pidFile;
@@ -265,7 +260,6 @@ public class PicocliMigrator implements Callable<Integer> {
         migrator.setHandler(objectHandler);
         migrator.setPidListManagers(pidListManagerList);
         migrator.setContinueOnError(continueOnError);
-        migrator.setMaxErrors(maxErrors);
 
         try {
             migrator.run();

--- a/src/main/java/org/fcrepo/migration/PicocliMigrator.java
+++ b/src/main/java/org/fcrepo/migration/PicocliMigrator.java
@@ -106,7 +106,8 @@ public class PicocliMigrator implements Callable<Integer> {
     private boolean continueOnError;
 
     @Option(names = {"--max-errors", "-M"}, defaultValue = "0", showDefaultValue = ALWAYS, order = 23,
-            description = "Maximum number of errors in sequence to skip before exiting.  Used in conjunction with --continue-on-error.  Default: no maximum")
+            description = "Maximum number of errors in a row to skip before exiting. " +
+                    "Used in conjunction with --continue-on-error.  Default: no maximum")
     private int maxErrors;
 
     @Option(names = {"--pid-file", "-p"}, order = 24,

--- a/src/main/java/org/fcrepo/migration/PicocliMigrator.java
+++ b/src/main/java/org/fcrepo/migration/PicocliMigrator.java
@@ -101,32 +101,36 @@ public class PicocliMigrator implements Callable<Integer> {
             description = "Resume from last successfully migrated Fedora 3 object")
     private boolean resume;
 
-    @Option(names = {"--continue-on-error", "-c"}, defaultValue = "false", showDefaultValue = ALWAYS, order = 22,
+    @Option(names = {"--continue-on-error", "-c"}, defaultValue = "false", showDefaultValue = ALWAYS, order = 23,
             description = "Continue to next PID if an error occurs (instead of exiting). Disabled by default.")
     private boolean continueOnError;
 
-    @Option(names = {"--pid-file", "-p"}, order = 23,
+    @Option(names = {"--max-errors", "-M"}, defaultValue = "0", showDefaultValue = ALWAYS, order = 23,
+            description = "Maximum number of errors in sequence to skip before exiting.  Used in conjunction with --continue-on-error.  Default: no maximum")
+    private int maxErrors;
+
+    @Option(names = {"--pid-file", "-p"}, order = 24,
             description = "PID file listing which Fedora 3 objects to migrate")
     private File pidFile;
 
-    @Option(names = {"--index-dir", "-i"}, order = 24,
+    @Option(names = {"--index-dir", "-i"}, order = 25,
             description = "Directory where cached index of datastreams (will reuse index if already exists)")
     private File indexDir;
 
-    @Option(names = {"--extensions", "-x"}, defaultValue = "false", showDefaultValue = ALWAYS, order = 25,
+    @Option(names = {"--extensions", "-x"}, defaultValue = "false", showDefaultValue = ALWAYS, order = 26,
             description = "Add file extensions to migrated datastreams based on mimetype recorded in FOXML")
     private boolean addExtensions;
 
-    @Option(names = {"--f3hostname", "-f"}, defaultValue = "fedora.info", showDefaultValue = ALWAYS, order = 26,
+    @Option(names = {"--f3hostname", "-f"}, defaultValue = "fedora.info", showDefaultValue = ALWAYS, order = 27,
             description = "Hostname of Fedora 3, used for replacing placeholder in 'E' and 'R' datastream URLs")
     private String f3hostname;
 
-    @Option(names = {"--username", "-u"}, defaultValue = "fedoraAdmin", showDefaultValue = ALWAYS, order = 27,
+    @Option(names = {"--username", "-u"}, defaultValue = "fedoraAdmin", showDefaultValue = ALWAYS, order = 28,
             description = "The username to associate with all of the migrated resources.")
     private String user;
 
     @Option(names = {"--user-uri", "-U"}, defaultValue = "info:fedora/fedoraAdmin", showDefaultValue = ALWAYS,
-            order = 28, description = "The username to associate with all of the migrated resources.")
+            order = 29, description = "The username to associate with all of the migrated resources.")
     private String userUri;
 
     @Option(names = {"--debug"}, order = 30, description = "Enables debug logging")
@@ -260,6 +264,7 @@ public class PicocliMigrator implements Callable<Integer> {
         migrator.setHandler(objectHandler);
         migrator.setPidListManagers(pidListManagerList);
         migrator.setContinueOnError(continueOnError);
+        migrator.setMaxErrors(maxErrors);
 
         try {
             migrator.run();

--- a/src/main/java/org/fcrepo/migration/foxml/FoxmlInputStreamFedoraObjectProcessor.java
+++ b/src/main/java/org/fcrepo/migration/foxml/FoxmlInputStreamFedoraObjectProcessor.java
@@ -164,11 +164,14 @@ public class FoxmlInputStreamFedoraObjectProcessor implements FedoraObjectProces
                 reader.next();
             }
 
-        } catch (XMLStreamException | JAXBException e) {
+        } catch (Exception e) {
             handler.abortObject(objectInfo);
-            cleanUpTempFiles();
+            if (e instanceof RuntimeException) {
+                throw (RuntimeException) e;
+            }
             throw new RuntimeException(e);
         } finally {
+            cleanUpTempFiles();
             close();
         }
     }
@@ -191,7 +194,9 @@ public class FoxmlInputStreamFedoraObjectProcessor implements FedoraObjectProces
 
     private void cleanUpTempFiles() {
         for (final File f : this.tempFiles) {
-            f.delete();
+            if (f.exists()) {
+                f.delete();
+            }
         }
     }
 

--- a/src/main/java/org/fcrepo/migration/handlers/ObjectAbstractionStreamingFedoraObjectHandler.java
+++ b/src/main/java/org/fcrepo/migration/handlers/ObjectAbstractionStreamingFedoraObjectHandler.java
@@ -86,33 +86,36 @@ public class ObjectAbstractionStreamingFedoraObjectHandler implements StreamingF
 
     @Override
     public void completeObject(final ObjectInfo object) {
-        handler.processObject(new ObjectReference() {
-            @Override
-            public ObjectInfo getObjectInfo() {
-                return objectInfo;
-            }
+        try {
+            handler.processObject(new ObjectReference() {
+                @Override
+                public ObjectInfo getObjectInfo() {
+                    return objectInfo;
+                }
 
-            @Override
-            public ObjectProperties getObjectProperties() {
-                return objectProperties;
-            }
+                @Override
+                public ObjectProperties getObjectProperties() {
+                    return objectProperties;
+                }
 
-            @Override
-            public List<String> listDatastreamIds() {
-                return dsIds;
-            }
+                @Override
+                public List<String> listDatastreamIds() {
+                    return dsIds;
+                }
 
-            @Override
-            public List<DatastreamVersion> getDatastreamVersions(final String datastreamId) {
-                return dsIdToVersionListMap.get(datastreamId);
-            }
+                @Override
+                public List<DatastreamVersion> getDatastreamVersions(final String datastreamId) {
+                    return dsIdToVersionListMap.get(datastreamId);
+                }
 
-            @Override
-            public boolean hadFedora2Disseminators() {
-                return disseminatorsSkipped > 0;
-            }
-        });
-        cleanForReuse();
+                @Override
+                public boolean hadFedora2Disseminators() {
+                    return disseminatorsSkipped > 0;
+                }
+            });
+        } finally {
+            cleanForReuse();
+        }
     }
 
     @Override

--- a/src/test/java/org/fcrepo/migration/pidlist/UserProvidedPidListManagerIT.java
+++ b/src/test/java/org/fcrepo/migration/pidlist/UserProvidedPidListManagerIT.java
@@ -90,6 +90,7 @@ public class UserProvidedPidListManagerIT {
         writer.newLine();
         writer.write("example:1");
         writer.flush();
+        writer.close();
 
         final UserProvidedPidListManager manager = new UserProvidedPidListManager(pidFile);
 
@@ -109,6 +110,7 @@ public class UserProvidedPidListManagerIT {
         writer.newLine();
         writer.write("example:1");
         writer.flush();
+        writer.close();
 
         // There are three test OCFL objects: example%3a1, example%3a2, example%3a3
         migrator.setPidListManagers(Collections.singletonList(new UserProvidedPidListManager(pidFile)));


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3460

# What does this Pull Request do?
Resolve problems introduced into processing state when using the `--continue-on-error` flag to skip errors
Update README with current flags and their usage

# What's new?
Clean up resources after exceptions thrown while processing an object, in order to start with a clean state for processing the next object in the queue.
Documentation of `--continue-on-error` flag in README, other minor usage doc updates

# How should this be tested?

I used a test set of 15 test objects to migrate, and deleted some datastreams from the F3 filesystem.

* First test: no continue-on-error, two datastreams deleted
  Expected: migration halts after first missing datastream
  Actual = Expected

* Second test: continue-on-error, datastreams in two consecutive objects deleted
  Expected: migration skips two objects with missing datastreams, rest are processed
  Actual = Expected

* Third test: continue-on-error, datastreams in two non-consecutive objects deleted
  Expected: migration skips first object with missing datastream, processes the next good objects, skips second object with missing datastream, processes the rest
  Actual = Expected

* Fourth test: continue-on-error, datastreams in every object in test set deleted
  Expected: migration attempts and skips every object
  Actual = Expected

# Additional Notes:

This PR does not address implementation of the ``--max-errors` feature described in the JIRA ticket.

# Interested parties
@awoods 
@dbernstein 
@pwinckles 
