### PR TITLE
Fix Deleted and Inactive migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,11 @@ The utility will perform various mapping operations in order to fit the fedora 2
 * TODO: is there more?
 
 Migrations to Fedora 6 may take a different approach, writing migrated objects directly to the filesystem as [OCFL](https://ocfl.io/draft/spec/)
-objects.  Additionally, a "minimal" migration mode is available that performs fewer transformations to migrated content.
-In particular:
+objects.
 
-* There is a 1:1 correspondence between fedora 3 objects and OCFL objects.  Fedora 3 datastreams appear as files within the resulting OCFL objects.
+* There is a 1:1 correspondence between Fedora 3 objects and OCFL objects.  Fedora 3 datastreams appear as files within the resulting OCFL objects.
 * RDF is not re-mapped, `info:fedora/` subjects and objects are kept intact as-is
-* FOXML object and datastream properties are represented as triples in additional sidecar files as per the mapping defined in `${migration.mapping.file}`. See example [custom-mapping.properties](https://github.com/fcrepo-exts/migration-utils/blob/master/src/main/resources/custom-mapping.properties).
+* FOXML object and datastream properties are represented as triples in additional sidecar files
 
 ## Status
 
@@ -71,6 +70,8 @@ Usage: migration-utils [-chrVx] [--debug] -a=<targetDir>
   -a, --target-dir=<targetDir>
                              Directory where OCFL storage root and supporting
                                state will be written
+  -I, --delete-inactive      Migrate objects and datastreams in the Inactive
+                               state as deleted. Default: false.
   -m, --migration-type=<migrationType>
                              Type of OCFL objects to migrate to. Choices:
                                FEDORA_OCFL | PLAIN_OCFL

--- a/src/main/java/org/fcrepo/migration/PicocliMigrator.java
+++ b/src/main/java/org/fcrepo/migration/PicocliMigrator.java
@@ -89,6 +89,10 @@ public class PicocliMigrator implements Callable<Integer> {
             description = "Directory where OCFL storage root and supporting state will be written")
     private File targetDir;
 
+    @Option(names = {"--delete-inactive", "-I"}, defaultValue = "false", showDefaultValue = ALWAYS, order = 18,
+            description = "Migrate objects and datastreams in the Inactive state as deleted. Default: false.")
+    private boolean deleteInactive;
+
     @Option(names = {"--migration-type", "-m"}, defaultValue = "FEDORA_OCFL", showDefaultValue = ALWAYS, order = 19,
             description = "Type of OCFL objects to migrate to. Choices: FEDORA_OCFL | PLAIN_OCFL")
     private MigrationType migrationType;
@@ -240,7 +244,7 @@ public class PicocliMigrator implements Callable<Integer> {
                 ocflStagingDir.toPath(), migrationType, user, userUri).getObject();
 
         final FedoraObjectVersionHandler archiveGroupHandler =
-                new ArchiveGroupHandler(ocflSessionFactory, migrationType, addExtensions, user);
+                new ArchiveGroupHandler(ocflSessionFactory, migrationType, addExtensions, deleteInactive, user);
         final FedoraObjectHandler versionHandler = new VersionAbstractionFedoraObjectHandler(archiveGroupHandler);
         final StreamingFedoraObjectHandler objectHandler = new ObjectAbstractionStreamingFedoraObjectHandler(
                 versionHandler);

--- a/src/test/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandlerTest.java
+++ b/src/test/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandlerTest.java
@@ -616,12 +616,14 @@ public class ArchiveGroupHandlerTest {
         if (isFirst) {
             final var properties = objectProperties(List.of(
                     objectProperty("info:fedora/fedora-system:def/view#lastModifiedDate", Instant.now().toString()),
-                    objectProperty("info:fedora/fedora-system:def/model#createdDate", Instant.now().toString())
+                    objectProperty("info:fedora/fedora-system:def/model#createdDate", Instant.now().toString()),
+                    objectProperty("info:fedora/fedora-system:def/model#state", "Active")
             ));
             when(mock.getObjectProperties()).thenReturn(properties);
         }
         when(mock.getObject()).thenReturn(null);
         when(mock.listChangedDatastreams()).thenReturn(datastreamVersions);
+        when(mock.getVersionDate()).thenReturn(Instant.now().toString());
         return mock;
     }
 

--- a/src/test/resources/spring/ocfl-pid-it-setup.xml
+++ b/src/test/resources/spring/ocfl-pid-it-setup.xml
@@ -79,6 +79,7 @@
         <constructor-arg name="sessionFactory" ref="ocflSessionFactory" />
         <constructor-arg name="migrationType" value="FEDORA_OCFL" />
         <constructor-arg name="addDatastreamExtensions" value="false" />
+        <constructor-arg name="deleteInactive" value="false" />
         <constructor-arg name="user" value="fedoraAdmin" />
     </bean>
 

--- a/src/test/resources/spring/ocfl-user-it-setup.xml
+++ b/src/test/resources/spring/ocfl-user-it-setup.xml
@@ -79,6 +79,7 @@
         <constructor-arg name="sessionFactory" ref="ocflSessionFactory" />
         <constructor-arg name="migrationType" value="FEDORA_OCFL" />
         <constructor-arg name="addDatastreamExtensions" value="false" />
+        <constructor-arg name="deleteInactive" value="false" />
         <constructor-arg name="user" value="fedoraAdmin" />
     </bean>
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3211

# What does this Pull Request do?

* Objects and datastreams that are in a Deleted state are migrated and then removed from the head version
* By default Inactive objects and datastreams are migrated the same as Active objects and datastreams
* A flag, `-I`, was added to migrate Inactive objects and datastreams the same as Deleted objects and datastreams
* If an object is in a Deleted state, then this state also applies to all of its datastreams

# How should this be tested?

Migrate F3 content that contains Deleted or Inactive resources. See that they are not present in the head version, but are in earlier versions. Start F6 on the migrated content.

# Interested parties
@fcrepo/committers
