### PR TITLE
fix tests after content size type change

### DIFF
--- a/src/test/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandlerTest.java
+++ b/src/test/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandlerTest.java
@@ -731,9 +731,9 @@ public class ArchiveGroupHandlerTest {
             assertThat(headers.getLastModifiedDate().toString(), containsString(date));
             assertThat(headers.getCreatedDate().toString(), containsString(date));
             if (INLINE.equals(datastreamVersion.getDatastreamInfo().getControlGroup())) {
-                assertNotEquals(Long.valueOf(datastreamVersion.getSize()), headers.getContentSize());
+                assertNotEquals(datastreamVersion.getSize(), headers.getContentSize());
             } else {
-                assertEquals(Long.valueOf(datastreamVersion.getSize()), headers.getContentSize());
+                assertEquals(datastreamVersion.getSize(), headers.getContentSize());
             }
             assertEquals(datastreamVersion.getMimeType(), headers.getMimeType());
             assertEquals(dsId, headers.getFilename());


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3524

**This PR depends on https://github.com/fcrepo/fcrepo-storage-ocfl/pull/20**

# What does this Pull Request do?

Fixes a couple of tests that were expecting `contentSize` to be a `Long`.

# Interested parties
@fcrepo/committers
