### PR TITLE
Add a new data directory

### DIFF
--- a/src/main/java/org/fcrepo/migration/PicocliMigrator.java
+++ b/src/main/java/org/fcrepo/migration/PicocliMigrator.java
@@ -191,14 +191,20 @@ public class PicocliMigrator implements Callable<Integer> {
             targetDir.mkdirs();
         }
 
+        // Fedora 6.0.0 expects a data directory at the top.
+        final File dataDir = targetDir.toPath().resolve("data").toFile();
+        if (!dataDir.exists()) {
+            dataDir.mkdirs();
+        }
+
         // Create OCFL Storage dir
-        final File ocflStorageDir = new File(targetDir, "ocfl");
+        final File ocflStorageDir = new File(dataDir, "ocfl-root");
         if (!ocflStorageDir.exists()) {
             ocflStorageDir.mkdirs();
         }
 
         // Create Staging dir
-        final File ocflStagingDir = new File(targetDir, "staging");
+        final File ocflStagingDir = new File(dataDir, "staging");
         if (!ocflStagingDir.exists()) {
             ocflStagingDir.mkdirs();
         }
@@ -210,8 +216,8 @@ public class PicocliMigrator implements Callable<Integer> {
         }
 
         // Which F3 source are we using? - verify associated options
-        ObjectSource objectSource;
-        InternalIDResolver idResolver;
+        final ObjectSource objectSource;
+        final InternalIDResolver idResolver;
         switch (f3SourceType) {
             case EXPORTED:
                 notNull(f3ExportedDir, "f3ExportDir must be used with 'exported' source!");


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3556

# What does this Pull Request do?

Adds a `data` directory under the `--target` directory as Fedora 6 expects this by default. Also renames the `ocfl` directory to `ocfl-root`

# How should this be tested?

Migrate some records, stand up F6 with `-Dfcrepo.home=<targetDir from migration>` and it should display the records with no additional steps.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo-exts/committers
