### PR TITLE
upgraded to ocfl-java 0.2

### DIFF
--- a/src/main/java/org/fcrepo/migration/OcflSessionFactoryFactoryBean.java
+++ b/src/main/java/org/fcrepo/migration/OcflSessionFactoryFactoryBean.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import edu.wisc.library.ocfl.core.OcflRepositoryBuilder;
-import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedTruncatedNTupleConfig;
+import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedNTupleLayoutConfig;
 import edu.wisc.library.ocfl.core.path.mapper.LogicalPathMappers;
 import edu.wisc.library.ocfl.core.storage.filesystem.FileSystemOcflStorage;
 import org.apache.commons.lang3.SystemUtils;
@@ -73,7 +73,7 @@ public class OcflSessionFactoryFactoryBean implements FactoryBean<OcflObjectSess
                 LogicalPathMappers.percentEncodingWindowsMapper() : LogicalPathMappers.percentEncodingLinuxMapper();
 
         final var ocflRepo =  new OcflRepositoryBuilder()
-                .layoutConfig(new HashedTruncatedNTupleConfig())
+                .defaultLayoutConfig(new HashedNTupleLayoutConfig())
                 .logicalPathMapper(logicalPathMapper)
                 .storage(FileSystemOcflStorage.builder().repositoryRoot(ocflRoot).build())
                 .workDir(stagingDir)

--- a/src/test/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandlerTest.java
+++ b/src/test/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandlerTest.java
@@ -7,7 +7,7 @@ import edu.wisc.library.ocfl.api.MutableOcflRepository;
 import edu.wisc.library.ocfl.api.model.FileDetails;
 import edu.wisc.library.ocfl.api.model.ObjectVersionId;
 import edu.wisc.library.ocfl.core.OcflRepositoryBuilder;
-import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedTruncatedNTupleConfig;
+import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedNTupleLayoutConfig;
 import edu.wisc.library.ocfl.core.path.mapper.LogicalPathMappers;
 import edu.wisc.library.ocfl.core.storage.filesystem.FileSystemOcflStorage;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -96,7 +96,7 @@ public class ArchiveGroupHandlerTest {
                 LogicalPathMappers.percentEncodingWindowsMapper() : LogicalPathMappers.percentEncodingLinuxMapper();
 
         ocflRepo = new OcflRepositoryBuilder()
-                .layoutConfig(new HashedTruncatedNTupleConfig())
+                .defaultLayoutConfig(new HashedNTupleLayoutConfig())
                 .logicalPathMapper(logicalPathMapper)
                 .storage(FileSystemOcflStorage.builder().repositoryRoot(ocflRoot).build())
                 .workDir(staging)

--- a/src/test/java/org/fcrepo/migration/handlers/ocfl/PlainOcflObjectSessionFactoryTest.java
+++ b/src/test/java/org/fcrepo/migration/handlers/ocfl/PlainOcflObjectSessionFactoryTest.java
@@ -18,7 +18,7 @@ package org.fcrepo.migration.handlers.ocfl;
 
 import edu.wisc.library.ocfl.api.MutableOcflRepository;
 import edu.wisc.library.ocfl.core.OcflRepositoryBuilder;
-import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedTruncatedNTupleConfig;
+import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedNTupleLayoutConfig;
 import edu.wisc.library.ocfl.core.path.mapper.LogicalPathMappers;
 import edu.wisc.library.ocfl.core.storage.filesystem.FileSystemOcflStorage;
 import org.apache.commons.lang3.SystemUtils;
@@ -56,7 +56,7 @@ public class PlainOcflObjectSessionFactoryTest {
                 LogicalPathMappers.percentEncodingWindowsMapper() : LogicalPathMappers.percentEncodingLinuxMapper();
 
         ocflRepo = new OcflRepositoryBuilder()
-                .layoutConfig(new HashedTruncatedNTupleConfig())
+                .defaultLayoutConfig(new HashedNTupleLayoutConfig())
                 .logicalPathMapper(logicalPathMapper)
                 .storage(FileSystemOcflStorage.builder().repositoryRoot(ocflRoot).build())
                 .workDir(staging)

--- a/src/test/java/org/fcrepo/migration/handlers/ocfl/PlainOcflObjectSessionTest.java
+++ b/src/test/java/org/fcrepo/migration/handlers/ocfl/PlainOcflObjectSessionTest.java
@@ -19,7 +19,7 @@ package org.fcrepo.migration.handlers.ocfl;
 import edu.wisc.library.ocfl.api.MutableOcflRepository;
 import edu.wisc.library.ocfl.api.model.ObjectVersionId;
 import edu.wisc.library.ocfl.core.OcflRepositoryBuilder;
-import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedTruncatedNTupleConfig;
+import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedNTupleLayoutConfig;
 import edu.wisc.library.ocfl.core.path.mapper.LogicalPathMappers;
 import edu.wisc.library.ocfl.core.storage.filesystem.FileSystemOcflStorage;
 import org.apache.commons.io.IOUtils;
@@ -66,7 +66,7 @@ public class PlainOcflObjectSessionTest {
                 LogicalPathMappers.percentEncodingWindowsMapper() : LogicalPathMappers.percentEncodingLinuxMapper();
 
         ocflRepo = new OcflRepositoryBuilder()
-                .layoutConfig(new HashedTruncatedNTupleConfig())
+                .defaultLayoutConfig(new HashedNTupleLayoutConfig())
                 .logicalPathMapper(logicalPathMapper)
                 .storage(FileSystemOcflStorage.builder().repositoryRoot(ocflRoot).build())
                 .workDir(staging)


### PR DESCRIPTION
**Jira:** https://jira.lyrasis.org/browse/FCREPO-3590

**This PR depends on https://github.com/fcrepo/fcrepo-storage-ocfl/pull/27**

Upgrades ocfl-java to the latest version.

A key difference in this version is that the storage layout extension definition is moved into the `extensions` directory. While the layout extension we're using has not been merged yet, it is unlikely that it'll need to be updated again.

This change does mean that the layout config in the storage root will no longer be read. Existing repositories with the storage layout in the old location are still usable, but `ocfl-java` will **not** write the storage layout to the new location for an existing repository. You either need to recreate the repository or write it manually.

To manually create it, write the following to `ocfl-root/extensions/0004-hashed-n-tuple-storage-layout/config.json`:

```json
{
  "digestAlgorithm" : "sha256",
  "tupleSize" : 3,
  "numberOfTuples" : 3,
  "shortObjectRoot" : false,
  "extensionName" : "0004-hashed-n-tuple-storage-layout"
}
```

