### PR TITLE
fixed the ITs

### DIFF
--- a/src/test/java/org/fcrepo/migration/pidlist/UserProvidedPidListManagerIT.java
+++ b/src/test/java/org/fcrepo/migration/pidlist/UserProvidedPidListManagerIT.java
@@ -17,7 +17,6 @@
 package org.fcrepo.migration.pidlist;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.fcrepo.migration.Migrator;
 import org.junit.After;
 import org.junit.Assert;
@@ -28,8 +27,11 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileFilter;
 import java.io.FileWriter;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 
 /**
@@ -47,8 +49,6 @@ public class UserProvidedPidListManagerIT {
     private File storage;
     private File staging;
     private File pidFile;
-
-    private FileFilter fileFilter;
 
     @Before
     public void setup() throws Exception {
@@ -72,7 +72,6 @@ public class UserProvidedPidListManagerIT {
 
         context = new ClassPathXmlApplicationContext("spring/ocfl-user-it-setup.xml");
         migrator = (Migrator) context.getBean("migrator");
-        fileFilter = DirectoryFileFilter.INSTANCE;
     }
 
     @After
@@ -98,8 +97,7 @@ public class UserProvidedPidListManagerIT {
         migrator.setPidListManagers(Collections.singletonList(manager));
         migrator.run();
 
-        final int numObjects = storage.listFiles(fileFilter).length;
-        Assert.assertEquals(3, numObjects) ;
+        Assert.assertEquals(3, countDirectories(storage.toPath())) ;
     }
 
     @Test
@@ -117,8 +115,17 @@ public class UserProvidedPidListManagerIT {
         migrator.run();
         context.close();
 
-        final int numObjects = storage.listFiles(fileFilter).length;
-        Assert.assertEquals(2, numObjects);
+        Assert.assertEquals(2, countDirectories(storage.toPath()));
+    }
+
+    private long countDirectories(final Path path) {
+        try (final var list = Files.list(path)) {
+            return list.filter(Files::isDirectory)
+                    .filter(dir -> !"extensions".equals(dir.getFileName().toString()))
+                    .count();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
 }


### PR DESCRIPTION
The ITests were broken after upgrading to ocfl-java 0.2 due to the addition of the `extensions` directory. Unclear why this wasn't caught before.