### PR TITLE
FCREPO-3618 - update target-dir and working-dir

### DIFF
--- a/src/main/java/org/fcrepo/migration/PicocliMigrator.java
+++ b/src/main/java/org/fcrepo/migration/PicocliMigrator.java
@@ -194,7 +194,10 @@ public class PicocliMigrator implements Callable<Integer> {
             targetDir.mkdirs();
         }
 
-        notNull(workingDir, "workingDir must be provided!");
+        if (workingDir == null) {
+            LOGGER.info("No working-dir option passed in - using current directory.");
+            workingDir = new File(System.getProperty("user.dir"));
+        }
         if (!workingDir.exists()) {
             workingDir.mkdirs();
         }

--- a/src/main/java/org/fcrepo/migration/PicocliMigrator.java
+++ b/src/main/java/org/fcrepo/migration/PicocliMigrator.java
@@ -204,14 +204,8 @@ public class PicocliMigrator implements Callable<Integer> {
         indexDir = new File(workingDir, "index");
 
         if (migrationType == MigrationType.FEDORA_OCFL) {
-            // Fedora 6.0.0 expects a data directory at the top.
-            final File dataDir = targetDir.toPath().resolve("data").toFile();
-            if (!dataDir.exists()) {
-                dataDir.mkdirs();
-            }
-
-            // Create OCFL Storage dir
-            ocflStorageDir = new File(dataDir, "ocfl-root");
+            // Fedora 6.0.0 expects a data/ocfl-root structure
+            ocflStorageDir = targetDir.toPath().resolve("data").resolve("ocfl-root").toFile();
             if (!ocflStorageDir.exists()) {
                 ocflStorageDir.mkdirs();
             }

--- a/src/main/java/org/fcrepo/migration/PicocliMigrator.java
+++ b/src/main/java/org/fcrepo/migration/PicocliMigrator.java
@@ -230,7 +230,7 @@ public class PicocliMigrator implements Callable<Integer> {
 
         // Which F3 source are we using? - verify associated options
         final ObjectSource objectSource;
-        final InternalIDResolver idResolver;
+        InternalIDResolver idResolver = null;
         switch (f3SourceType) {
             case EXPORTED:
                 notNull(f3ExportedDir, "f3ExportDir must be used with 'exported' source!");
@@ -288,6 +288,9 @@ public class PicocliMigrator implements Callable<Integer> {
             migrator.run();
         } finally {
             ocflSessionFactory.close();
+            if (idResolver != null) {
+                idResolver.close();
+            }
             FileUtils.deleteDirectory(ocflStagingDir);
         }
 

--- a/src/main/java/org/fcrepo/migration/PicocliMigrator.java
+++ b/src/main/java/org/fcrepo/migration/PicocliMigrator.java
@@ -194,6 +194,7 @@ public class PicocliMigrator implements Callable<Integer> {
             targetDir.mkdirs();
         }
 
+        notNull(workingDir, "workingDir must be provided!");
         if (!workingDir.exists()) {
             workingDir.mkdirs();
         }

--- a/src/main/java/org/fcrepo/migration/foxml/DirectoryScanningIDResolver.java
+++ b/src/main/java/org/fcrepo/migration/foxml/DirectoryScanningIDResolver.java
@@ -59,6 +59,7 @@ public abstract class DirectoryScanningIDResolver implements InternalIDResolver 
      * file containing that datastream content.
      */
     private final IndexSearcher searcher;
+    private final IndexReader reader;
     private final FSDirectory fsDirectory;
 
     /**
@@ -118,12 +119,12 @@ public abstract class DirectoryScanningIDResolver implements InternalIDResolver 
         }
 
         fsDirectory = FSDirectory.open(indexDir.toPath());
-        final IndexReader reader = DirectoryReader.open(fsDirectory);
+        reader = DirectoryReader.open(fsDirectory);
         searcher = new IndexSearcher(reader);
     }
 
     public void close() throws IOException {
-        searcher.getIndexReader().close();
+        reader.close();
         fsDirectory.close();
     }
 

--- a/src/main/java/org/fcrepo/migration/foxml/DirectoryScanningIDResolver.java
+++ b/src/main/java/org/fcrepo/migration/foxml/DirectoryScanningIDResolver.java
@@ -59,6 +59,7 @@ public abstract class DirectoryScanningIDResolver implements InternalIDResolver 
      * file containing that datastream content.
      */
     private final IndexSearcher searcher;
+    private final FSDirectory fsDirectory;
 
     /**
      * directory scanning ID resolver
@@ -116,12 +117,14 @@ public abstract class DirectoryScanningIDResolver implements InternalIDResolver 
             }
         }
 
-        final IndexReader reader = DirectoryReader.open(FSDirectory.open(indexDir.toPath()));
+        fsDirectory = FSDirectory.open(indexDir.toPath());
+        final IndexReader reader = DirectoryReader.open(fsDirectory);
         searcher = new IndexSearcher(reader);
     }
 
     public void close() throws IOException {
         searcher.getIndexReader().close();
+        fsDirectory.close();
     }
 
     @Override

--- a/src/main/java/org/fcrepo/migration/foxml/DirectoryScanningIDResolver.java
+++ b/src/main/java/org/fcrepo/migration/foxml/DirectoryScanningIDResolver.java
@@ -120,6 +120,10 @@ public abstract class DirectoryScanningIDResolver implements InternalIDResolver 
         searcher = new IndexSearcher(reader);
     }
 
+    public void close() throws IOException {
+        searcher.getIndexReader().close();
+    }
+
     @Override
     public CachedContent resolveInternalID(final String id) {
         try {

--- a/src/main/java/org/fcrepo/migration/foxml/InternalIDResolver.java
+++ b/src/main/java/org/fcrepo/migration/foxml/InternalIDResolver.java
@@ -33,6 +33,7 @@ public interface InternalIDResolver {
 
     /**
      * Closes any open resources.
+     * @throws IOException
      */
     public void close() throws IOException;
 }

--- a/src/main/java/org/fcrepo/migration/foxml/InternalIDResolver.java
+++ b/src/main/java/org/fcrepo/migration/foxml/InternalIDResolver.java
@@ -15,6 +15,8 @@
  */
 package org.fcrepo.migration.foxml;
 
+import java.io.IOException;
+
 /**
  * An interface whose implementations serve as a mechanism to
  * resolve internal (to fedora/FOXML) IDs.
@@ -28,4 +30,9 @@ public interface InternalIDResolver {
      * @return the binary content for the datastream referenced by the internal id
      */
     public CachedContent resolveInternalID(String id);
+
+    /**
+     * Closes any open resources.
+     */
+    public void close() throws IOException;
 }

--- a/src/test/java/org/fcrepo/migration/Example1TestSuite.java
+++ b/src/test/java/org/fcrepo/migration/Example1TestSuite.java
@@ -289,6 +289,9 @@ public abstract class Example1TestSuite {
         public CachedContent resolveInternalID(final String id) {
             return null;
         }
+
+        @Override
+        public void close() throws IOException { };
     }
 
 }

--- a/src/test/java/org/fcrepo/migration/PicocliIT.java
+++ b/src/test/java/org/fcrepo/migration/PicocliIT.java
@@ -29,8 +29,8 @@ public class PicocliIT {
         try {
             FileUtils.forceDelete(tmpDir.toFile());
         } catch (IOException io) {
-            System.err.println(io.getMessage());
-            throw io;
+            System.err.println("Error cleaning up " + tmpDir.toString());
+            io.printStackTrace();
         }
     }
 

--- a/src/test/java/org/fcrepo/migration/PicocliIT.java
+++ b/src/test/java/org/fcrepo/migration/PicocliIT.java
@@ -1,0 +1,66 @@
+package org.fcrepo.migration;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+import org.junit.After;
+import org.junit.Before;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author bcail
+ */
+public class PicocliIT {
+
+    private Path tmpDir;
+
+    @Before
+    public void setup() throws IOException {
+        tmpDir = Files.createTempDirectory("migration-utils");
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        FileUtils.forceDelete(tmpDir.toFile());
+    }
+
+    @Test
+    public void testPlainOcfl() throws Exception {
+        final Path targetDir = tmpDir.resolve("target");
+        final Path workingDir = tmpDir.resolve("working");
+        final String[] args = {"--target-dir", targetDir.toString(), "--working-dir", workingDir.toString(),
+                "--source-type", "LEGACY","--migration-type", "PLAIN_OCFL",
+                "--datastreams-dir","src/test/resources/legacyFS/datastreams/2015/0430/16/01",
+                "--objects-dir", "src/test/resources/legacyFS/objects/2015/0430/16/01"};
+        final PicocliMigrator migrator = new PicocliMigrator();
+        final CommandLine cmd = new CommandLine(migrator);
+
+        cmd.execute(args);
+        assertTrue(Files.list(targetDir).anyMatch(element -> element.endsWith("0=ocfl_1.0")));
+        assertTrue(Files.list(workingDir).anyMatch(element -> element.endsWith("index")));
+        assertTrue(Files.list(workingDir).anyMatch(element -> element.endsWith("pid")));
+    }
+
+    @Test
+    public void testFedoraOcfl() throws Exception {
+        final Path targetDir = tmpDir.resolve("target");
+        final Path workingDir = tmpDir.resolve("working");
+        final String[] args = {"--target-dir", targetDir.toString(), "--working-dir", workingDir.toString(),
+                "--source-type", "LEGACY","--migration-type", "FEDORA_OCFL",
+                "--datastreams-dir","src/test/resources/legacyFS/datastreams/2015/0430/16/01",
+                "--objects-dir", "src/test/resources/legacyFS/objects/2015/0430/16/01"};
+        final PicocliMigrator migrator = new PicocliMigrator();
+        final CommandLine cmd = new CommandLine(migrator);
+
+        cmd.execute(args);
+        assertTrue(Files.list(targetDir.resolve("data").resolve("ocfl-root"))
+                .anyMatch(element -> element.endsWith("0=ocfl_1.0")));
+        assertTrue(Files.list(workingDir).anyMatch(element -> element.endsWith("index")));
+        assertTrue(Files.list(workingDir).anyMatch(element -> element.endsWith("pid")));
+    }
+}

--- a/src/test/java/org/fcrepo/migration/PicocliIT.java
+++ b/src/test/java/org/fcrepo/migration/PicocliIT.java
@@ -26,7 +26,12 @@ public class PicocliIT {
 
     @After
     public void tearDown() throws IOException {
-        FileUtils.forceDelete(tmpDir.toFile());
+        try {
+            FileUtils.forceDelete(tmpDir.toFile());
+        } catch (IOException io) {
+            System.err.println(io.getMessage());
+            throw io;
+        }
     }
 
     @Test

--- a/src/test/java/org/fcrepo/migration/PicocliIT.java
+++ b/src/test/java/org/fcrepo/migration/PicocliIT.java
@@ -52,6 +52,23 @@ public class PicocliIT {
     }
 
     @Test
+    public void testPlainOcflNoWorkingDirOption() throws Exception {
+        final Path targetDir = tmpDir.resolve("target");
+        final String[] args = {"--target-dir", targetDir.toString(),
+                "--source-type", "LEGACY","--migration-type", "PLAIN_OCFL",
+                "--datastreams-dir","src/test/resources/legacyFS/datastreams/2015/0430/16/01",
+                "--objects-dir", "src/test/resources/legacyFS/objects/2015/0430/16/01"};
+        final PicocliMigrator migrator = new PicocliMigrator();
+        final CommandLine cmd = new CommandLine(migrator);
+
+        cmd.execute(args);
+        final Path workingDir = Path.of(System.getProperty("user.dir"));
+        assertTrue(Files.list(targetDir).anyMatch(element -> element.endsWith("0=ocfl_1.0")));
+        assertTrue(Files.list(workingDir).anyMatch(element -> element.endsWith("index")));
+        assertTrue(Files.list(workingDir).anyMatch(element -> element.endsWith("pid")));
+    }
+
+    @Test
     public void testFedoraOcfl() throws Exception {
         final Path targetDir = tmpDir.resolve("target");
         final Path workingDir = tmpDir.resolve("working");


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.lyrasis.org/browse/FCREPO-3618)

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Updates target-dir to be the storage root for PLAIN_OCFL (target-dir still contains data/ocfl-root for FEDORA_OCFL). Puts index dir and pid dir into a new working-dir.

The index-dir option is removed, and the working-dir option is added.

# How should this be tested?

java -jar migration-utils-6.0.0-SNAPSHOT-driver.jar --source-type=legacy --datastreams-dir=<datastreams_dir> --objects-dir=<objects_dir> --target-dir=<target_dir> --migration-type=FEDORA_OCFL --working-dir=<working_dir> --limit=1
 * <target_dir> should contain data/ocfl-root
 * <working_dir> should contain index/ and pid/

java -jar migration-utils-6.0.0-SNAPSHOT-driver.jar --source-type=legacy --datastreams-dir=<datastreams_dir> --objects-dir=<objects_dir> --target-dir=<target_dir> --migration-type=PLAIN_OCFL --working-dir=<working_dir> --limit=1
 * <target_dir> should be OCFL storage root
 * <working_dir> should contain index/ and pid/

# Additional Notes:
This changes this index directory, so any existing indexes would need to be moved or regenerated. The pid/resume.txt also would need to be moved/regenerated.

If someone is using PLAIN_OCFL and has a partial migration, this changes the location of the storage root.

# Interested parties
@fcrepo/committers
