### PR TITLE
Make the digest algorithm configurable

### DIFF
--- a/src/test/java/org/fcrepo/migration/PicocliIT.java
+++ b/src/test/java/org/fcrepo/migration/PicocliIT.java
@@ -1,18 +1,32 @@
 package org.fcrepo.migration;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import edu.wisc.library.ocfl.core.OcflRepositoryBuilder;
 import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedNTupleIdEncapsulationLayoutConfig;
 import edu.wisc.library.ocfl.core.storage.filesystem.FileSystemOcflStorage;
-import org.apache.commons.io.FileUtils;
-import org.junit.Test;
-import org.junit.After;
-import org.junit.Before;
 import picocli.CommandLine;
-
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author bcail
@@ -30,7 +44,7 @@ public class PicocliIT {
     public void tearDown() throws IOException {
         try {
             FileUtils.forceDelete(tmpDir.toFile());
-        } catch (IOException io) {
+        } catch (final IOException io) {
             System.err.println("Error cleaning up " + tmpDir.toString());
             io.printStackTrace();
         }
@@ -112,5 +126,125 @@ public class PicocliIT {
         //verify that the correct storage layout was used - encapsulation directory is the encoded object id
         assertTrue(Files.list(targetDir.resolve("5b5").resolve("62d").resolve("d69"))
                 .anyMatch(f -> f.endsWith("info%3afedora%2fexample%3a1")));
+    }
+
+    @Test
+    public void testInvalidDigestAlgorithm() throws Exception {
+        final Path targetDir = tmpDir.resolve("target");
+        final Path workingDir = tmpDir.resolve("working");
+        final String[] args = {"--target-dir", targetDir.toString(), "--working-dir", workingDir.toString(),
+                "--source-type", "LEGACY","--migration-type", "PLAIN_OCFL",
+                "--datastreams-dir","src/test/resources/legacyFS/datastreams/2015/0430/16/01",
+                "--objects-dir", "src/test/resources/legacyFS/objects/2015/0430/16/01",
+                "--algorithm", "sha384"};
+        final PicocliMigrator migrator = new PicocliMigrator();
+        final CommandLine cmd = new CommandLine(migrator);
+
+        final int result = cmd.execute(args);
+        assertEquals(1, result);
+    }
+
+    /**
+     * MD5 is a supported algorithm under an OCFL extension, but we don't support it.
+     */
+    @Test
+    public void testInvalidForUsDigestAlgorithm() {
+        final Path targetDir = tmpDir.resolve("target");
+        final Path workingDir = tmpDir.resolve("working");
+        final String[] args = {"--target-dir", targetDir.toString(), "--working-dir", workingDir.toString(),
+                "--source-type", "LEGACY","--migration-type", "PLAIN_OCFL",
+                "--datastreams-dir","src/test/resources/legacyFS/datastreams/2015/0430/16/01",
+                "--objects-dir", "src/test/resources/legacyFS/objects/2015/0430/16/01",
+                "--algorithm", "md5"};
+        final PicocliMigrator migrator = new PicocliMigrator();
+        final CommandLine cmd = new CommandLine(migrator);
+
+        final int result = cmd.execute(args);
+        assertEquals(1, result);
+    }
+
+    @Test
+    public void testSha256DigestAlgorithm() throws Exception {
+        final Path targetDir = tmpDir.resolve("target");
+        final Path workingDir = tmpDir.resolve("working");
+        final String[] args = {"--target-dir", targetDir.toString(), "--working-dir", workingDir.toString(),
+                "--source-type", "LEGACY","--migration-type", "PLAIN_OCFL",
+                "--datastreams-dir","src/test/resources/legacyFS/datastreams/2015/0430/16/01",
+                "--objects-dir", "src/test/resources/legacyFS/objects/2015/0430/16/01",
+                "--algorithm", "sha256"};
+        final PicocliMigrator migrator = new PicocliMigrator();
+        final CommandLine cmd = new CommandLine(migrator);
+
+        final int result = cmd.execute(args);
+        assertEquals(0, result);
+        assertTrue(Files.list(targetDir).anyMatch(element -> element.endsWith("0=ocfl_1.0")));
+        final Path baseDir = targetDir.resolve("5b5").resolve("62d").resolve("d69")
+                .resolve("5b562dd698f17e3198e007e6f77f9e48f20a556c6bae84e6fc8d98544831daa6");
+        final File inventory = baseDir.resolve("inventory.json").toFile();
+        assertTrue(inventory.exists());
+        validateManifests(inventory, "SHA-256", baseDir);
+    }
+
+    /**
+     * Validate the manifest digests in an inventory file.
+     * @param inventory the inventory file
+     * @param digestAlgo the digest algorithm
+     * @param baseDir the path of the OCFL object
+     * @throws IOException issues opening the inventory file.
+     * @throws NoSuchAlgorithmException issues creating a MessageDigest.
+     */
+    private void validateManifests(final File inventory, final String digestAlgo, final Path baseDir)
+            throws IOException, NoSuchAlgorithmException {
+        final var manifests = getManifests(inventory);
+        final MessageDigest md = MessageDigest.getInstance(digestAlgo);
+        for (final var entry : manifests.entrySet()) {
+            final File f = baseDir.resolve(entry.getKey()).toFile();
+            assertTrue(f.exists());
+            final String digest = getDigest(new FileInputStream(f), md, 2048);
+            assertEquals(entry.getValue(), digest);
+        }
+    }
+
+    /**
+     * Utility to get a message digest for a file.
+     * @param stream the input stream of the file
+     * @param md the message digest to calculate
+     * @param byteSize size of file to read per loop.
+     * @return the hash
+     * @throws IOException problems opening the inputstream
+     */
+    private String getDigest(final InputStream stream, final MessageDigest md, final int byteSize) throws IOException {
+        md.reset();
+        final byte[] byteArray = new byte[byteSize];
+        int bytes;
+        while ((bytes = stream.read(byteArray)) != -1) {
+            md.update(byteArray, 0, bytes);
+        }
+        return new String(Hex.encodeHex(md.digest()));
+    }
+
+    /**
+     * Parse the manifest section out of an OCFL inventory file and return a map of filename -> hash
+     * @param inventory the OCFL inventory file
+     * @return map of file paths from the OCFL object root and their digests
+     * @throws IOException issues opening the inventory file.
+     */
+    private Map<String, String> getManifests(final File inventory) throws IOException {
+        final ObjectMapper mapper = new ObjectMapper();
+        final JsonNode rootNode = mapper.readTree(inventory);
+        final JsonNode manifestNode = rootNode.findValues("manifest").get(0);
+        final Map<String, String> fileManifest = new HashMap<>();
+        final var fieldIter = manifestNode.fields();
+        while (fieldIter.hasNext()) {
+            final var entry = fieldIter.next();
+            final String hash = entry.getKey();
+            if (entry.getValue().isArray()) {
+                // More than one file with the same hash
+                entry.getValue().spliterator().forEachRemaining(file -> fileManifest.put(file.asText(), hash));
+            } else {
+                fileManifest.put(entry.getValue().asText(), hash);
+            }
+        }
+        return fileManifest;
     }
 }

--- a/src/test/java/org/fcrepo/migration/PicocliIT.java
+++ b/src/test/java/org/fcrepo/migration/PicocliIT.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
@@ -15,6 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -200,27 +200,9 @@ public class PicocliIT {
         for (final var entry : manifests.entrySet()) {
             final File f = baseDir.resolve(entry.getKey()).toFile();
             assertTrue(f.exists());
-            final String digest = getDigest(new FileInputStream(f), md, 2048);
+            final String digest = new String(Hex.encodeHex(DigestUtils.digest(md, new FileInputStream(f))));
             assertEquals(entry.getValue(), digest);
         }
-    }
-
-    /**
-     * Utility to get a message digest for a file.
-     * @param stream the input stream of the file
-     * @param md the message digest to calculate
-     * @param byteSize size of file to read per loop.
-     * @return the hash
-     * @throws IOException problems opening the inputstream
-     */
-    private String getDigest(final InputStream stream, final MessageDigest md, final int byteSize) throws IOException {
-        md.reset();
-        final byte[] byteArray = new byte[byteSize];
-        int bytes;
-        while ((bytes = stream.read(byteArray)) != -1) {
-            md.update(byteArray, 0, bytes);
-        }
-        return new String(Hex.encodeHex(md.digest()));
     }
 
     /**


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3582

# What does this Pull Request do?
Adds a new `--algorithm` option to choose between sha256 or sha512 inventory manifests.

# How should this be tested?

Migration some sample data, get inventory.json with sha512 digests. Then run the same command with `--algorithm sha256` and get sha256 digests.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo-exts/committers
