### PR TITLE
Check for existing object before migrating

### DIFF
--- a/src/main/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandler.java
+++ b/src/main/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandler.java
@@ -159,6 +159,9 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
             final OcflObjectSession session = sessionFactory.newSession(f6ObjectId);
 
             if (ov.isFirstVersion()) {
+                if (session.containsResource(f6ObjectId)) {
+                    throw new RuntimeException(f6ObjectId + " already exists!");
+                }
                 objectState = getObjectState(ov, objectId);
                 // Object properties are written only once (as fcrepo3 object properties were unversioned).
                 if (foxmlFile) {

--- a/src/main/java/org/fcrepo/migration/handlers/ocfl/PlainOcflObjectSession.java
+++ b/src/main/java/org/fcrepo/migration/handlers/ocfl/PlainOcflObjectSession.java
@@ -231,7 +231,11 @@ public class PlainOcflObjectSession implements OcflObjectSession {
 
     @Override
     public boolean containsResource(final String resourceId) {
-        throw new UnsupportedOperationException("Not implemented");
+        if (ocflRepo.containsObject(ocflObjectId)) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     private Path stagingPath(final String path) {

--- a/src/main/java/org/fcrepo/migration/handlers/ocfl/PlainOcflObjectSession.java
+++ b/src/main/java/org/fcrepo/migration/handlers/ocfl/PlainOcflObjectSession.java
@@ -231,11 +231,7 @@ public class PlainOcflObjectSession implements OcflObjectSession {
 
     @Override
     public boolean containsResource(final String resourceId) {
-        if (ocflRepo.containsObject(ocflObjectId)) {
-            return true;
-        } else {
-            return false;
-        }
+        return ocflRepo.containsObject(ocflObjectId);
     }
 
     private Path stagingPath(final String path) {


### PR DESCRIPTION
Check for existing object before migrating
* * *

**JIRA Ticket**: (https://jira.lyrasis.org/browse/FCREPO-3643)

# What does this Pull Request do?
When migrating an object, if the object already exists in the OCFL repo, throw an exception instead of migrating content on top of what's already there.

# How should this be tested?
There are a couple automated tests, but to test manually, run the migration over the same content twice - it should fail the second time because the first object was already migrated.

# Additional Notes:
Documentation will need to be checked/updated.

# Interested parties
@fcrepo/committers
