### PR TITLE
migrate FOXML file as deleted

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,23 @@ Usage: migration-utils [-chrVx] [--debug] -a=<targetDir>
   -a, --target-dir=<targetDir>
                              Directory where OCFL storage root and supporting
                                state will be written
+  -i, --working-dir=<workingDir>
+                             Directory where supporting state will be written
+                               (cached index of datastreams, ...)
   -I, --delete-inactive      Migrate objects and datastreams in the Inactive
                                state as deleted. Default: false.
   -m, --migration-type=<migrationType>
                              Type of OCFL objects to migrate to. Choices:
                                FEDORA_OCFL | PLAIN_OCFL
                                Default: FEDORA_OCFL
+      --id-prefix=<idPrefix> Only use this for PLAIN_OCFL migrations: Prefix to
+                               add to PIDs for OCFL object IDs - defaults to
+                               info:fedora/, like Fedora3
+                               Default: info:fedora/
+      --foxml-file           Migrate FOXML file as a whole file, instead of
+                               creating property files. FOXML file will be
+                               migrated, then marked as deleted so it doesn't
+                               show up as an active file.
   -l, --limit=<objectLimit>  Limit number of objects to be processed.
                                Default: no limit
   -r, --resume               Resume from last successfully migrated Fedora 3
@@ -72,8 +83,6 @@ Usage: migration-utils [-chrVx] [--debug] -a=<targetDir>
                                of exiting). Disabled by default.
                                Default: false
   -p, --pid-file=<pidFile>   PID file listing which Fedora 3 objects to migrate
-  -i, --index-dir=<indexDir> Directory where cached index of datastreams (will
-                               reuse index if already exists)
   -x, --extensions           Add file extensions to migrated datastreams based
                                on mimetype recorded in FOXML
                                Default: false
@@ -87,6 +96,14 @@ Usage: migration-utils [-chrVx] [--debug] -a=<targetDir>
   -U, --user-uri=<userUri>   The username to associate with all of the migrated
                                resources.
                                Default: info:fedora/fedoraAdmin
+      --algorithm=<digestAlgorithm>
+                             The digest algorithm to use in the OCFL objects
+                               created. Either sha256 or sha512
+                               Default: sha512
+      --no-checksum-validation
+                             Disable validation that datastream content matches
+                               Fedora 3 checksum.
+                               Default: false
       --debug                Enables debug logging
 ```
 

--- a/src/main/java/org/fcrepo/migration/PicocliMigrator.java
+++ b/src/main/java/org/fcrepo/migration/PicocliMigrator.java
@@ -112,7 +112,8 @@ public class PicocliMigrator implements Callable<Integer> {
     private String idPrefix;
 
     @Option(names = {"--foxml-file"}, defaultValue = "false", order = 21,
-            description = "Migrate foxml file as a whole file, instead of creating property files")
+            description = "Migrate FOXML file as a whole file, instead of creating property files. FOXML file will"
+                + " be migrated, then marked as deleted so it doesn't show up as an active file.")
     private boolean foxmlFile;
 
     @Option(names = {"--limit", "-l"}, defaultValue = "-1", order = 22,

--- a/src/main/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandler.java
+++ b/src/main/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandler.java
@@ -287,6 +287,12 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
             final var now = OffsetDateTime.now();
             final var hasDeletes = new AtomicBoolean(false);
 
+            //delete foxmlFile if we migrated it - it's not an active file in the object
+            if (foxmlFile) {
+                hasDeletes.set(true);
+                deleteDatastream(f6ObjectId + "/FOXML", now.toInstant(), session);
+            }
+
             if (OBJ_DELETED.equals(objectState) || (deleteInactive && OBJ_INACTIVE.equals(objectState))) {
                 hasDeletes.set(true);
 

--- a/src/test/java/org/fcrepo/migration/PicocliIT.java
+++ b/src/test/java/org/fcrepo/migration/PicocliIT.java
@@ -16,7 +16,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+import edu.wisc.library.ocfl.api.model.FileDetails;
 import edu.wisc.library.ocfl.api.model.ObjectVersionId;
+import edu.wisc.library.ocfl.api.model.VersionDetails;
 import edu.wisc.library.ocfl.api.model.VersionInfo;
 import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedNTupleLayoutConfig;
 import org.apache.commons.codec.binary.Hex;
@@ -207,13 +209,24 @@ public class PicocliIT {
         }
         final var expectedFiles = new ArrayList<String>();
         expectedFiles.add("AUDIT");
-        expectedFiles.add("FOXML");
         expectedFiles.add("DS2");
         expectedFiles.add("DS1");
         expectedFiles.add("DS4");
         expectedFiles.add("DS3");
         expectedFiles.add("DC");
         assertEquals(expectedFiles, files);
+        //now check for a FOXML, which should show up in a previous version
+        final var versions = ocflRepo.describeObject("example:1").getVersionMap().values();
+        boolean foundFoxml = false;
+        for (VersionDetails v : versions) {
+            for (FileDetails f : v.getFiles()) {
+                if (f.getPath().equals("FOXML")) {
+                    foundFoxml = true;
+                    break;
+                }
+            }
+        }
+        assertTrue(foundFoxml);
     }
 
     @Test


### PR DESCRIPTION
migrate FOXML file as deleted
* * *

**JIRA Ticket**: (https://jira.lyrasis.org/browse/FCREPO-3639)

# What does this Pull Request do?
For --foxml-file migrations - after migrating FOXML into the OCFL object, it deletes the FOXML so it's in the object history, but not a currently active file.

# How should this be tested?
Has automated test, but to test manually: migrate an object with the --foxml-file option, and verify that the FOXML is not in the latest object version, but is in a previous version.

# Interested parties
@fcrepo/committers
