### PR TITLE
upgrade jena version and cleanup resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <spring.version>5.2.1.RELEASE</spring.version>
     <lucene.version>7.1.0</lucene.version>
-    <jena.version>2.12.1</jena.version>
+    <jena.version>3.17.0</jena.version>
     <checkstyle.plugin.version>3.1.1</checkstyle.plugin.version>
     <logback.version>1.1.2</logback.version>
     <mockito.version>2.22.0</mockito.version>

--- a/src/main/java/org/fcrepo/migration/foxml/NamespacePrefixMapper.java
+++ b/src/main/java/org/fcrepo/migration/foxml/NamespacePrefixMapper.java
@@ -15,12 +15,12 @@
  */
 package org.fcrepo.migration.foxml;
 
+import org.apache.jena.update.UpdateRequest;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Properties;
-
-import com.hp.hpl.jena.update.UpdateRequest;
 
 /**
  * Utility bean to set namespace prefixes in a SPARQL update.


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3689

# What does this Pull Request do?

* Upgrades to the current version of Jena
* Explicitly closes Jena resources so they don't go to the finalizer to cleanup

# How should this be tested?

Everything should work the same, except it should hopefully use less memory and not get bogged down.

# Interested parties
@fcrepo/committers
