### PR TITLE
Expose Fedora 3 file for managed datastreams

### DIFF
--- a/src/main/java/org/fcrepo/migration/DatastreamVersion.java
+++ b/src/main/java/org/fcrepo/migration/DatastreamVersion.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
 
-
 /**
  * An interface defining access to information about a version of a
  * fedora datastream.
@@ -141,5 +140,4 @@ public interface DatastreamVersion {
      * @return  True if this is the last version, false otherwise.
      */
     public boolean isLastVersionIn(ObjectReference obj);
-
 }

--- a/src/main/java/org/fcrepo/migration/DatastreamVersion.java
+++ b/src/main/java/org/fcrepo/migration/DatastreamVersion.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
 
+
 /**
  * An interface defining access to information about a version of a
  * fedora datastream.
@@ -105,6 +106,16 @@ public interface DatastreamVersion {
     public InputStream getContent() throws IOException;
 
     /**
+     * Get the file backing this datastream if it exists.
+     * Used by fcrepo-migration-validator in order to get direct access to files.
+     *
+     * @return the file
+     */
+    default Optional<File> getFile() {
+        return Optional.empty();
+    }
+
+    /**
      * Returns the URL to which an External (X) or Redirect (R) datastream
      * points.  Throws IllegalStateException if this isn't an external or
      * redirect datastream.
@@ -131,7 +142,4 @@ public interface DatastreamVersion {
      */
     public boolean isLastVersionIn(ObjectReference obj);
 
-    default Optional<File> getFile() {
-        return Optional.empty();
-    }
 }

--- a/src/main/java/org/fcrepo/migration/DatastreamVersion.java
+++ b/src/main/java/org/fcrepo/migration/DatastreamVersion.java
@@ -15,8 +15,10 @@
  */
 package org.fcrepo.migration;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 
 /**
  * An interface defining access to information about a version of a
@@ -128,4 +130,8 @@ public interface DatastreamVersion {
      * @return  True if this is the last version, false otherwise.
      */
     public boolean isLastVersionIn(ObjectReference obj);
+
+    default Optional<File> getFile() {
+        return Optional.empty();
+    }
 }

--- a/src/main/java/org/fcrepo/migration/foxml/CachedContent.java
+++ b/src/main/java/org/fcrepo/migration/foxml/CachedContent.java
@@ -15,8 +15,10 @@
  */
 package org.fcrepo.migration.foxml;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 
 /**
  * An interface representing content that is accessible as an InputStream.
@@ -30,5 +32,9 @@ public interface CachedContent {
      * @throws IOException IO exception
      */
     public InputStream getInputStream() throws IOException;
+
+    default Optional<File> getFile() {
+        return Optional.empty();
+    }
 
 }

--- a/src/main/java/org/fcrepo/migration/foxml/CachedContent.java
+++ b/src/main/java/org/fcrepo/migration/foxml/CachedContent.java
@@ -40,5 +40,4 @@ public interface CachedContent {
     default Optional<File> getFile() {
         return Optional.empty();
     }
-
 }

--- a/src/main/java/org/fcrepo/migration/foxml/CachedContent.java
+++ b/src/main/java/org/fcrepo/migration/foxml/CachedContent.java
@@ -33,6 +33,10 @@ public interface CachedContent {
      */
     public InputStream getInputStream() throws IOException;
 
+    /**
+     * get the file backing the CachedContent if it exists
+     * @return the file
+     */
     default Optional<File> getFile() {
         return Optional.empty();
     }

--- a/src/main/java/org/fcrepo/migration/foxml/FileCachedContent.java
+++ b/src/main/java/org/fcrepo/migration/foxml/FileCachedContent.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 
 /**
  * A CashedContent implementation that exposes content stored in a
@@ -43,5 +44,10 @@ public class FileCachedContent implements CachedContent {
             throw new IllegalStateException("Cached content is not available.");
         }
         return new FileInputStream(file);
+    }
+
+    @Override
+    public Optional<File> getFile() {
+        return Optional.ofNullable(file);
     }
 }

--- a/src/main/java/org/fcrepo/migration/foxml/FoxmlInputStreamFedoraObjectProcessor.java
+++ b/src/main/java/org/fcrepo/migration/foxml/FoxmlInputStreamFedoraObjectProcessor.java
@@ -80,6 +80,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -448,6 +449,11 @@ public class FoxmlInputStreamFedoraObjectProcessor implements FedoraObjectProces
                 reader.next();
             }
 
+        }
+
+        @Override
+        public Optional<File> getFile() {
+            return dsContent.getFile();
         }
 
         private String extractInlineXml() throws XMLStreamException {

--- a/src/test/java/org/fcrepo/migration/Example1TestSuite.java
+++ b/src/test/java/org/fcrepo/migration/Example1TestSuite.java
@@ -90,6 +90,7 @@ public abstract class Example1TestSuite {
         Assert.assertEquals("2015-01-27T19:07:33.120Z", audit0.getCreated());
         Assert.assertEquals("text/xml", audit0.getMimeType());
         Assert.assertEquals("info:fedora/fedora-system:format/xml.fedora.audit", audit0.getFormatUri());
+        Assert.assertTrue(audit0.getFile().isEmpty());
     }
 
     @Test
@@ -112,6 +113,7 @@ public abstract class Example1TestSuite {
                 "  <dc:title>This is an example object.</dc:title>\n" +
                 "  <dc:identifier>example:1</dc:identifier>\n" +
                 "</oai_dc:dc>", IOUtils.toString(dc0.getContent()).trim());
+        Assert.assertTrue(dc0.getFile().isEmpty());
     }
 
     @Test
@@ -131,6 +133,7 @@ public abstract class Example1TestSuite {
         Assert.assertEquals("<test>\n" +
                 "  This is a test.\n" +
                 "</test>", IOUtils.toString(ds1.getContent()).trim());
+        Assert.assertTrue(ds1.getFile().isEmpty());
 
         final DatastreamVersion ds2 = getResult().dsVersions.get(3);
         Assert.assertEquals("DS1", ds2.getDatastreamInfo().getDatastreamId());
@@ -148,6 +151,7 @@ public abstract class Example1TestSuite {
         Assert.assertEquals("<test>\n" +
                 "  This is a test that was edited.\n" +
                 "</test>", IOUtils.toString(ds2.getContent()).trim());
+        Assert.assertTrue(ds2.getFile().isEmpty());
     }
 
     @Test
@@ -167,6 +171,7 @@ public abstract class Example1TestSuite {
         Assert.assertTrue("Managed Base64 encoded datastream must be preserved.", IOUtils.contentEquals(
                 getClass().getClassLoader().getResourceAsStream("small-mountains.jpg"),
                 new ByteArrayInputStream(getResult().cachedDsVersionBinaries.get(4))));
+        Assert.assertTrue(ds2.getFile().isPresent());
     }
 
     @Test
@@ -184,6 +189,7 @@ public abstract class Example1TestSuite {
         ds3.getContent().close();
         Assert.assertEquals("http://" + SimpleObjectSource.LOCAL_FEDORA_SERVER + "/fedora/get/example:1/DS2",
                 getFetcher().getLastUrl().toExternalForm());
+        Assert.assertTrue(ds3.getFile().isEmpty());
     }
 
     @Test
@@ -202,6 +208,7 @@ public abstract class Example1TestSuite {
         Assert.assertEquals("http://" + SimpleObjectSource.LOCAL_FEDORA_SERVER
                         + "/fedora/objects/example:1/datastreams/DS2/content",
                 getFetcher().getLastUrl().toExternalForm());
+        Assert.assertTrue(ds4.getFile().isEmpty());
     }
 
     public static class SimpleObjectSource implements ObjectSource {


### PR DESCRIPTION
# What does this Pull Request do?

This adds a few methods in order to retrieve the File backing the `FileCachedContent` for datastreams. The main motivation for doing this was to simplify the validations in `fcrepo-migration-validator` when comparing the size of datastreams between the F3 and F6.

# What's new?

* Added method to get the File backing a DatastreamVersion if it exists

# How should this be tested?

* Example1TestSuite was updated to test the `getFile` call on each datastream, so this should be run to ensure all tests pass

# Interested parties

@fcrepo/committers
@dbernstein 