### PR TITLE
use UTC time for deleted resources final commit

### DIFF
--- a/src/main/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandler.java
+++ b/src/main/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandler.java
@@ -57,6 +57,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -293,7 +294,7 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
         final OcflObjectSession session = new OcflObjectSessionWrapper(sessionFactory.newSession(f6ObjectId));
 
         try {
-            final var now = OffsetDateTime.now();
+            final var now = OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC);
             final var hasDeletes = new AtomicBoolean(false);
 
             if (OBJ_DELETED.equals(objectState) || (deleteInactive && OBJ_INACTIVE.equals(objectState))) {


### PR DESCRIPTION
Use UTC time for deleted resources final commit
* * *

**JIRA Ticket**: (https://fedora-repository.atlassian.net/browse/FCREPO-3716)

# What does this Pull Request do?
This PR uses UTC time for the final commit that handles deleted resources in the migration.

# How should this be tested?
Try migrating an object that has the final deleted resources commit, and see that it uses local timezone. Apply this change, and it should use UTC time for the final commit instead.

# Interested parties
@fcrepo/committers
