### PR TITLE
Increment version to 6.1.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   </parent>
   <groupId>org.fcrepo.migration</groupId>
   <artifactId>migration-utils</artifactId>
-  <version>6.0.0-SNAPSHOT</version>
+  <version>6.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>migration-utils</name>


### PR DESCRIPTION
To prevent version number from colliding on main and 6.0.0-RC branches.