### PR TITLE
DRAFT: added option for migrating resources as atomic resources

### DIFF
--- a/src/main/java/org/fcrepo/migration/PicocliMigrator.java
+++ b/src/main/java/org/fcrepo/migration/PicocliMigrator.java
@@ -101,66 +101,70 @@ public class PicocliMigrator implements Callable<Integer> {
             description = "Migrate objects and datastreams in the Inactive state as deleted. Default: false.")
     private boolean deleteInactive;
 
-    @Option(names = {"--migration-type", "-m"}, defaultValue = "FEDORA_OCFL", showDefaultValue = ALWAYS, order = 19,
+    @Option(names = {"--resource-migration-type", "-R"}, defaultValue = "ARCHIVAL", showDefaultValue = ALWAYS, order = 19,
+            description = "Controls if objects are migrated as archival groups or atomic resources. Choices: ARCHIVAL | ATOMIC")
+    private ResourceMigrationType resourceMigrationType;
+
+    @Option(names = {"--migration-type", "-m"}, defaultValue = "FEDORA_OCFL", showDefaultValue = ALWAYS, order = 20,
             description = "Type of OCFL objects to migrate to. Choices: FEDORA_OCFL | PLAIN_OCFL")
     private MigrationType migrationType;
 
-    @Option(names = {"--id-prefix"}, defaultValue = DEFAULT_PREFIX, showDefaultValue = ALWAYS, order = 20,
+    @Option(names = {"--id-prefix"}, defaultValue = DEFAULT_PREFIX, showDefaultValue = ALWAYS, order = 21,
             description = "Only use this for PLAIN_OCFL migrations: Prefix to add to PIDs for OCFL object IDs"
                 + " - defaults to info:fedora/, like Fedora3")
     private String idPrefix;
 
-    @Option(names = {"--foxml-file"}, defaultValue = "false", order = 21,
+    @Option(names = {"--foxml-file"}, defaultValue = "false", order = 22,
             description = "Migrate FOXML file as a whole file, instead of creating property files. FOXML file will"
                 + " be migrated, then marked as deleted so it doesn't show up as an active file.")
     private boolean foxmlFile;
 
-    @Option(names = {"--limit", "-l"}, defaultValue = "-1", order = 22,
+    @Option(names = {"--limit", "-l"}, defaultValue = "-1", order = 23,
             description = "Limit number of objects to be processed.\n  Default: no limit")
     private int objectLimit;
 
-    @Option(names = {"--resume", "-r"}, defaultValue = "false", showDefaultValue = ALWAYS, order = 23,
+    @Option(names = {"--resume", "-r"}, defaultValue = "false", showDefaultValue = ALWAYS, order = 24,
             description = "Resume from last successfully migrated Fedora 3 object")
     private boolean resume;
 
-    @Option(names = {"--continue-on-error", "-c"}, defaultValue = "false", showDefaultValue = ALWAYS, order = 24,
+    @Option(names = {"--continue-on-error", "-c"}, defaultValue = "false", showDefaultValue = ALWAYS, order = 25,
             description = "Continue to next PID if an error occurs (instead of exiting). Disabled by default.")
     private boolean continueOnError;
 
-    @Option(names = {"--pid-file", "-p"}, order = 25,
+    @Option(names = {"--pid-file", "-p"}, order = 26,
             description = "PID file listing which Fedora 3 objects to migrate")
     private File pidFile;
 
-    @Option(names = {"--extensions", "-x"}, defaultValue = "false", showDefaultValue = ALWAYS, order = 26,
+    @Option(names = {"--extensions", "-x"}, defaultValue = "false", showDefaultValue = ALWAYS, order = 27,
             description = "Add file extensions to migrated datastreams based on mimetype recorded in FOXML")
     private boolean addExtensions;
 
-    @Option(names = {"--f3hostname", "-f"}, defaultValue = "fedora.info", showDefaultValue = ALWAYS, order = 27,
+    @Option(names = {"--f3hostname", "-f"}, defaultValue = "fedora.info", showDefaultValue = ALWAYS, order = 28,
             description = "Hostname of Fedora 3, used for replacing placeholder in 'E' and 'R' datastream URLs")
     private String f3hostname;
 
-    @Option(names = {"--username", "-u"}, defaultValue = "fedoraAdmin", showDefaultValue = ALWAYS, order = 28,
+    @Option(names = {"--username", "-u"}, defaultValue = "fedoraAdmin", showDefaultValue = ALWAYS, order = 29,
             description = "The username to associate with all of the migrated resources.")
     private String user;
 
     @Option(names = {"--user-uri", "-U"}, defaultValue = "info:fedora/fedoraAdmin", showDefaultValue = ALWAYS,
-            order = 29, description = "The username to associate with all of the migrated resources.")
+            order = 30, description = "The username to associate with all of the migrated resources.")
     private String userUri;
 
-    @Option(names = {"--algorithm"}, defaultValue = "sha512", showDefaultValue = ALWAYS, order = 30,
+    @Option(names = {"--algorithm"}, defaultValue = "sha512", showDefaultValue = ALWAYS, order = 31,
             description = "The digest algorithm to use in the OCFL objects created. Either sha256 or sha512")
     private String digestAlgorithm;
 
-    @Option(names = {"--no-checksum-validation"}, defaultValue = "false", showDefaultValue = ALWAYS, order = 31,
+    @Option(names = {"--no-checksum-validation"}, defaultValue = "false", showDefaultValue = ALWAYS, order = 32,
             description = "Disable validation that datastream content matches Fedora 3 checksum.")
     private boolean disableChecksumValidation;
 
-    @Option(names = {"--enable-metrics"}, defaultValue = "false", showDefaultValue = ALWAYS, order = 32,
+    @Option(names = {"--enable-metrics"}, defaultValue = "false", showDefaultValue = ALWAYS, order = 33,
             description = "Enable gathering of metrics for a Prometheus instance. " +
                           "\nNote: this requires port 8080 to be free in order for Prometheus to scrape metrics.")
     private boolean enableMetrics;
 
-    @Option(names = {"--debug"}, order = 32, description = "Enables debug logging")
+    @Option(names = {"--debug"}, order = 34, description = "Enables debug logging")
     private boolean debug;
 
     private File indexDir;
@@ -302,7 +306,9 @@ public class PicocliMigrator implements Callable<Integer> {
                 .getObject();
 
         final FedoraObjectVersionHandler archiveGroupHandler =
-                new ArchiveGroupHandler(ocflSessionFactory, migrationType, addExtensions, deleteInactive, foxmlFile,
+                new ArchiveGroupHandler(
+                        ocflSessionFactory, migrationType, resourceMigrationType,
+                        addExtensions, deleteInactive, foxmlFile,
                         user, idPrefix, disableChecksumValidation);
         final StreamingFedoraObjectHandler objectHandler = new ObjectAbstractionStreamingFedoraObjectHandler(
                 archiveGroupHandler);

--- a/src/main/java/org/fcrepo/migration/ResourceMigrationType.java
+++ b/src/main/java/org/fcrepo/migration/ResourceMigrationType.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.migration;
+
+/**
+ * Describes how resources should be modeled when migrated
+ *
+ * @author pwinckles
+ */
+public enum ResourceMigrationType {
+
+    /**
+     * Objects are migrated as archival groups and datastreams are migrated as archival group parts
+     */
+    ARCHIVAL,
+
+    /**
+     * Objects and datastreams are migrated as atomic resources
+     */
+    ATOMIC
+
+}

--- a/src/main/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandler.java
+++ b/src/main/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandler.java
@@ -41,6 +41,7 @@ import org.fcrepo.migration.FedoraObjectVersionHandler;
 import org.fcrepo.migration.MigrationType;
 import org.fcrepo.migration.ObjectInfo;
 import org.fcrepo.migration.ObjectVersionReference;
+import org.fcrepo.migration.ResourceMigrationType;
 import org.fcrepo.storage.ocfl.InteractionModel;
 import org.fcrepo.storage.ocfl.OcflObjectSession;
 import org.fcrepo.storage.ocfl.OcflObjectSessionFactory;
@@ -95,6 +96,7 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
     private static final Logger LOGGER = getLogger(ArchiveGroupHandler.class);
 
     private static final String FCREPO_ROOT = "info:fedora/";
+    private static final String FCRMETA_SUFFIX = "/fcr:metadata";
 
     private static final Map<String, String> externalHandlingMap = Map.of(
             "E", "proxy",
@@ -119,6 +121,7 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
     private final boolean deleteInactive;
     private final boolean foxmlFile;
     private final MigrationType migrationType;
+    private final ResourceMigrationType resourceMigrationType;
     private final String user;
     private final String idPrefix;
     private final Detector mimeDetector;
@@ -131,6 +134,8 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
      *        OCFL session factory
      * @param migrationType
      *        the type of migration to do
+     * @param resourceMigrationType
+     *        how resources should be migrated
      * @param addDatastreamExtensions
      *        true if datastreams should be written with file extensions
      * @param deleteInactive
@@ -146,6 +151,7 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
      */
     public ArchiveGroupHandler(final OcflObjectSessionFactory sessionFactory,
                                final MigrationType migrationType,
+                               final ResourceMigrationType resourceMigrationType,
                                final boolean addDatastreamExtensions,
                                final boolean deleteInactive,
                                final boolean foxmlFile,
@@ -154,6 +160,7 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
                                final boolean disableChecksumValidation) {
         this.sessionFactory = Preconditions.checkNotNull(sessionFactory, "sessionFactory cannot be null");
         this.migrationType = Preconditions.checkNotNull(migrationType, "migrationType cannot be null");
+        this.resourceMigrationType = Preconditions.checkNotNull(resourceMigrationType, "resourceMigrationType cannot be null");
         this.addDatastreamExtensions = addDatastreamExtensions;
         this.deleteInactive = deleteInactive;
         this.foxmlFile = foxmlFile;
@@ -193,10 +200,10 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
             // tracks the binaries that need their filename updated based on a RELS-INT removal
             final Map<String, String> relsDeletedFilenames = new HashMap<>();
 
-            final OcflObjectSession session = new OcflObjectSessionWrapper(sessionFactory.newSession(f6ObjectId));
+            final var objectSession = newSession(f6ObjectId);
 
             if (ov.isFirstVersion()) {
-                if (session.containsResource(f6ObjectId)) {
+                if (objectSession.containsResource(f6ObjectId)) {
                     throw new RuntimeException(f6ObjectId + " already exists!");
                 }
                 objectState = getObjectState(ov, objectId);
@@ -206,7 +213,7 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
                         final var foxmlDsId = f6ObjectId + "/FOXML";
                         final var headers = createHeaders(foxmlDsId, f6ObjectId,
                                 InteractionModel.NON_RDF).build();
-                        session.writeResource(headers, is);
+                        objectSession.writeResource(headers, is);
                         //mark FOXML as a deleted datastream so it gets deleted in handleDeletedResources()
                         datastreamStates.put(foxmlDsId, DS_DELETED);
                     } catch (IOException io) {
@@ -218,16 +225,21 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
                     final var content = getObjTriples(ov, objectId);
                     final var meta = MetaHolder.fromContent(content, objectHeaders);
                     metaMap.put(f6ObjectId, meta);
-                    session.writeResource(meta.headers.build(), meta.constructTriples());
+                    objectSession.writeResource(meta.headers.build(), meta.constructTriples());
                 }
             }
+
+            final var datastreamSessions = new HashMap<String, OcflObjectSession>();
 
             // Write datastreams and their metadata
             for (var dv : ov.listChangedDatastreams()) {
                 final var mimeType = resolveMimeType(dv);
                 final String dsId = dv.getDatastreamInfo().getDatastreamId();
-                final String f6DsId = resolveF6DatastreamId(dsId, f6ObjectId, mimeType);
+                final String f6DsId = resolveF6DatastreamId(dsId, f6ObjectId);
                 final var datastreamFilename = lastPartFromId(f6DsId);
+
+                final var datastreamSession = datastreamSessions.computeIfAbsent(f6DsId,
+                        k -> datastreamSession(f6DsId, objectSession));
 
                 if (dv.isFirstVersionIn(ov.getObject())) {
                     dsCreateDates.put(dsId, dv.getCreated());
@@ -251,10 +263,10 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
                     if (migrationType == MigrationType.PLAIN_OCFL) {
                         content = IOUtils.toInputStream(dv.getExternalOrRedirectURL(), StandardCharsets.UTF_8);
                     }
-                    session.writeResource(datastreamHeaders, content);
+                    datastreamSession.writeResource(datastreamHeaders, content);
                 } else {
                     try (var contentStream = dv.getContent()) {
-                        writeDatastreamContent(dv, datastreamHeaders, contentStream, session);
+                        writeDatastreamContent(dv, datastreamHeaders, contentStream, datastreamSession);
                     } catch (final IOException e) {
                         throw new UncheckedIOException(e);
                     }
@@ -311,13 +323,23 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
                 }
             }
 
-            writeMeta(toWrite, metaMap, session);
-            updateFilenames(relsFilenameUpdates, filenameMap, relsDeletedFilenames, session);
+            writeMeta(toWrite, metaMap, objectSession, datastreamSessions);
+            updateFilenames(relsFilenameUpdates, filenameMap, relsDeletedFilenames, objectSession, datastreamSessions);
 
             LOGGER.debug("Committing object <{}>", f6ObjectId);
 
-            session.versionCreationTimestamp(OffsetDateTime.parse(ov.getVersionDate()));
-            session.commit();
+            final var creationTimestamp = OffsetDateTime.parse(ov.getVersionDate());
+
+            objectSession.versionCreationTimestamp(creationTimestamp);
+            objectSession.commit();
+
+            if (resourceMigrationType == ResourceMigrationType.ATOMIC) {
+                datastreamSessions.forEach((id, session) -> {
+                    LOGGER.debug("Committing object <{}>", id);
+                    session.versionCreationTimestamp(creationTimestamp);
+                    session.commit();
+                });
+            }
         }
 
         handleDeletedResources(f6ObjectId, objectState, datastreamStates);
@@ -367,11 +389,13 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
      *
      * @param toWrite the set of resources that should be written to this version
      * @param metaMap the map of all known rdf resources
-     * @param session the current ocfl session
+     * @param objectSession the ocfl session for the object
+     * @param datastreamSessions the ocfl sessions for the datastreams
      */
     private void writeMeta(final Set<String> toWrite,
                            final Map<String, MetaHolder> metaMap,
-                           final OcflObjectSession session) {
+                           final OcflObjectSession objectSession,
+                           final Map<String, OcflObjectSession> datastreamSessions) {
         for (final var id : toWrite) {
             final var meta = metaMap.get(id);
 
@@ -380,6 +404,9 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
                 // Skip for now. The triples will be added once the datastream exists.
                 continue;
             }
+
+            final var session = datastreamSessions.computeIfAbsent(id.replace(FCRMETA_SUFFIX, ""),
+                    k -> datastreamSession(k, objectSession));
 
             // Need to copy over the memento created date from the existing headers because it may have been updated
             // when a description's binary was updated
@@ -398,9 +425,12 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
     private void updateFilenames(final Set<String> toUpdate,
                                  final Map<String, String> filenameMap,
                                  final Map<String, String> relsDeletedFilenames,
-                                 final OcflObjectSession session) {
+                                 final OcflObjectSession objectSession,
+                                 final Map<String, OcflObjectSession> datastreamSessions) {
         if (migrationType == MigrationType.FEDORA_OCFL) {
             toUpdate.forEach(id -> {
+                final var session = datastreamSessions.computeIfAbsent(id.replace(FCRMETA_SUFFIX, ""),
+                        k -> datastreamSession(k, objectSession));
                 final var origHeaders = session.readHeaders(id);
                 final var filename = filenameMap.get(id);
                 if (StringUtils.isNotBlank(filename)) {
@@ -409,6 +439,8 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
                 }
             });
             relsDeletedFilenames.forEach((id, filename) -> {
+                final var session = datastreamSessions.computeIfAbsent(id.replace(FCRMETA_SUFFIX, ""),
+                        k -> datastreamSession(k, objectSession));
                 final var origHeaders = session.readHeaders(id);
                 final var newHeaders = ResourceHeaders.builder(origHeaders).withFilename(filename).build();
                 session.writeHeaders(newHeaders);
@@ -469,7 +501,8 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
     private void handleDeletedResources(final String f6ObjectId,
                                         final String objectState,
                                         final Map<String, String> datastreamStates) {
-        final OcflObjectSession session = new OcflObjectSessionWrapper(sessionFactory.newSession(f6ObjectId));
+        final OcflObjectSession session = newSession(f6ObjectId);
+        final var datastreamSessions = new HashMap<String, OcflObjectSession>();
 
         try {
             final var now = OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC);
@@ -479,7 +512,9 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
                 hasDeletes.set(true);
 
                 datastreamStates.keySet().forEach(f6DsId -> {
-                    deleteDatastream(f6DsId, now.toInstant(), session);
+                    final var datastreamSession = datastreamSessions.computeIfAbsent(f6DsId,
+                            k -> datastreamSession(f6DsId, session));
+                    deleteDatastream(f6DsId, now.toInstant(), datastreamSession);
                 });
 
                 if (migrationType == MigrationType.PLAIN_OCFL) {
@@ -490,8 +525,10 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
             } else {
                 datastreamStates.forEach((f6DsId, state) -> {
                     if (DS_DELETED.equals(state) || (deleteInactive && DS_INACTIVE.equals(state))) {
+                        final var datastreamSession = datastreamSessions.computeIfAbsent(f6DsId,
+                                k -> datastreamSession(f6DsId, session));
                         hasDeletes.set(true);
-                        deleteDatastream(f6DsId, now.toInstant(), session);
+                        deleteDatastream(f6DsId, now.toInstant(), datastreamSession);
                     }
                 });
             }
@@ -499,8 +536,20 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
             if (hasDeletes.get()) {
                 session.versionCreationTimestamp(now);
                 session.commit();
+
+                if (resourceMigrationType == ResourceMigrationType.ATOMIC) {
+                    datastreamSessions.forEach((id, dsSession) -> {
+                        dsSession.versionCreationTimestamp(now);
+                        dsSession.commit();
+                    });
+                }
             } else {
                 session.abort();
+                if (resourceMigrationType == ResourceMigrationType.ATOMIC) {
+                    datastreamSessions.forEach((id, dsSession) -> {
+                        dsSession.abort();
+                    });
+                }
             }
         } catch (RuntimeException e) {
             session.abort();
@@ -509,14 +558,14 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
     }
 
     private String f6DescriptionId(final String f6ResourceId) {
-        return f6ResourceId + "/fcr:metadata";
+        return f6ResourceId + FCRMETA_SUFFIX;
     }
 
     private String lastPartFromId(final String id) {
         return id.substring(id.lastIndexOf('/') + 1);
     }
 
-    private String resolveF6DatastreamId(final String datastreamId, final String f6ObjectId, final String mimeType) {
+    private String resolveF6DatastreamId(final String datastreamId, final String f6ObjectId) {
         return f6ObjectId + "/" + datastreamId;
     }
 
@@ -533,7 +582,7 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
 
     private ResourceHeaders.Builder createObjectHeaders(final String f6ObjectId, final ObjectVersionReference ov) {
         final var headers = createHeaders(f6ObjectId, FCREPO_ROOT, InteractionModel.BASIC_CONTAINER);
-        headers.withArchivalGroup(true);
+        headers.withArchivalGroup(resourceMigrationType == ResourceMigrationType.ARCHIVAL);
         headers.withObjectRoot(true);
         headers.withLastModifiedBy(user);
         headers.withCreatedBy(user);
@@ -561,7 +610,9 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
                                                     final String createDate) {
         final var lastModified = Instant.parse(dv.getCreated());
         final var headers = createHeaders(f6DsId, f6ObjectId, InteractionModel.NON_RDF);
-        headers.withArchivalGroupId(f6ObjectId);
+        if (resourceMigrationType == ResourceMigrationType.ARCHIVAL) {
+            headers.withArchivalGroupId(f6ObjectId);
+        }
         headers.withFilename(filename);
         headers.withCreatedDate(Instant.parse(createDate));
         headers.withLastModifiedDate(lastModified);
@@ -576,7 +627,7 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
         }
 
         headers.withArchivalGroup(false);
-        headers.withObjectRoot(false);
+        headers.withObjectRoot(resourceMigrationType == ResourceMigrationType.ATOMIC);
         if (dv.getSize() > -1 && !INLINE_XML.equals(dv.getDatastreamInfo().getControlGroup())) {
             headers.withContentSize(dv.getSize());
         }
@@ -600,7 +651,9 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
         final var id = f6DescriptionId(f6DsId);
         final var headers = createHeaders(id, f6DsId, InteractionModel.NON_RDF_DESCRIPTION);
 
-        headers.withArchivalGroupId(datastreamHeaders.getArchivalGroupId());
+        if (resourceMigrationType == ResourceMigrationType.ARCHIVAL) {
+            headers.withArchivalGroupId(datastreamHeaders.getArchivalGroupId());
+        }
         headers.withCreatedDate(datastreamHeaders.getCreatedDate());
         headers.withLastModifiedDate(datastreamHeaders.getLastModifiedDate());
         headers.withCreatedBy(datastreamHeaders.getCreatedBy());
@@ -817,6 +870,26 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
             model.add(statement);
         }
         return splitModels;
+    }
+
+    /**
+     * Creates a new session for the datastream when migrating as atomic resources, or returns the object session,
+     * when migrating as archival groups.
+     *
+     * @param id the datastream's id in fedora 6
+     * @param objectSession the datastream's object session
+     * @return either a new datastream session or the object session
+     */
+    private OcflObjectSession datastreamSession(final String id, final OcflObjectSession objectSession) {
+        if (resourceMigrationType == ResourceMigrationType.ARCHIVAL) {
+            return objectSession;
+        } else {
+            return newSession(id);
+        }
+    }
+
+    private OcflObjectSession newSession(final String id) {
+        return new OcflObjectSessionWrapper(sessionFactory.newSession(id));
     }
 
     /**

--- a/src/test/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandlerTest.java
+++ b/src/test/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandlerTest.java
@@ -21,6 +21,7 @@ import org.fcrepo.migration.MigrationType;
 import org.fcrepo.migration.ObjectProperties;
 import org.fcrepo.migration.ObjectProperty;
 import org.fcrepo.migration.ObjectVersionReference;
+import org.fcrepo.migration.ResourceMigrationType;
 import org.fcrepo.storage.ocfl.CommitType;
 import org.fcrepo.storage.ocfl.DefaultOcflObjectSessionFactory;
 import org.fcrepo.storage.ocfl.InteractionModel;
@@ -1184,11 +1185,14 @@ public class ArchiveGroupHandlerTest {
     private ArchiveGroupHandler createHandler(final MigrationType migrationType,
                                               final boolean addExtensions,
                                               final boolean deleteInactive) {
+        // TODO
         if (migrationType == MigrationType.PLAIN_OCFL) {
-            return new ArchiveGroupHandler(plainSessionFactory, migrationType, addExtensions, deleteInactive,
+            return new ArchiveGroupHandler(plainSessionFactory, migrationType, ResourceMigrationType.ARCHIVAL,
+                    addExtensions, deleteInactive,
                     false, USER,"info:fedora/", false);
         } else {
-            return new ArchiveGroupHandler(sessionFactory, migrationType, addExtensions, deleteInactive, false, USER,
+            return new ArchiveGroupHandler(sessionFactory, migrationType, ResourceMigrationType.ARCHIVAL,
+                    addExtensions, deleteInactive, false, USER,
                     "info:fedora/", false);
         }
     }


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3775

# What does this Pull Request do?

1. Adds a `--resource-migration-type` flag that allows users to control if their objects are migrated as archival groups or atomic resources

# How should this be tested?

Migrate Fedora 3 objects with `--resource-migration-type ATOMIC` and see that they are migrated as atomic resources and not archival groups.

# Interested parties

@fcrepo/committers
