### PR TITLE
Alter test assertion to allow for ocfl 1.0 and 1.1

### DIFF
--- a/src/test/java/org/fcrepo/migration/PicocliIT.java
+++ b/src/test/java/org/fcrepo/migration/PicocliIT.java
@@ -64,6 +64,11 @@ public class PicocliIT {
         }
     }
 
+    private boolean checkDirForNamaste(final Path targetDir) throws IOException {
+        return Files.list(targetDir).map(Path::getFileName).map(Path::toString)
+                .anyMatch(e -> e.startsWith("0=ocfl_1."));
+    }
+
     @Test
     public void testPlainOcfl() throws Exception {
         final String[] args = {"--target-dir", targetDir.toString(), "--working-dir", workingDir.toString(),
@@ -74,7 +79,7 @@ public class PicocliIT {
         final CommandLine cmd = new CommandLine(migrator);
 
         cmd.execute(args);
-        assertTrue(Files.list(targetDir).anyMatch(element -> element.endsWith("0=ocfl_1.0")));
+        assertTrue(checkDirForNamaste(targetDir));
         final Path baseDir = targetDir.resolve("5b5").resolve("62d").resolve("d69")
                 .resolve("5b562dd698f17e3198e007e6f77f9e48f20a556c6bae84e6fc8d98544831daa6");
         final File inventory = baseDir.resolve("inventory.json").toFile();
@@ -95,7 +100,7 @@ public class PicocliIT {
 
         final int result = cmd.execute(args);
         assertEquals(0, result);
-        assertTrue(Files.list(targetDir).anyMatch(element -> element.endsWith("0=ocfl_1.0")));
+        assertTrue(checkDirForNamaste(targetDir));
         final Path baseDir = targetDir.resolve("750").resolve("677").resolve("e9b")
                 .resolve("750677e9b953845ba5069d27a3775fbced186987fd0f4a8c968ac457a7d415a8");
         final File inventory = baseDir.resolve("inventory.json").toFile();
@@ -129,7 +134,7 @@ public class PicocliIT {
 
         cmd.execute(args);
         final Path workingDir = Path.of(System.getProperty("user.dir"));
-        assertTrue(Files.list(targetDir).anyMatch(element -> element.endsWith("0=ocfl_1.0")));
+        assertTrue(checkDirForNamaste(targetDir));
         assertTrue(Files.list(workingDir).anyMatch(element -> element.endsWith("index")));
         assertTrue(Files.list(workingDir).anyMatch(element -> element.endsWith("pid")));
     }
@@ -144,8 +149,7 @@ public class PicocliIT {
         final CommandLine cmd = new CommandLine(migrator);
 
         cmd.execute(args);
-        assertTrue(Files.list(targetDir.resolve("data").resolve("ocfl-root"))
-                .anyMatch(element -> element.endsWith("0=ocfl_1.0")));
+        assertTrue(checkDirForNamaste(targetDir.resolve("data").resolve("ocfl-root")));
         assertTrue(Files.list(workingDir).anyMatch(element -> element.endsWith("index")));
         assertTrue(Files.list(workingDir).anyMatch(element -> element.endsWith("pid")));
     }
@@ -158,7 +162,7 @@ public class PicocliIT {
                 .storage(OcflStorageBuilder.builder().fileSystem(targetDir).build())
                 .workDir(tmpDir)
                 .build();
-        assertTrue(Files.list(targetDir).anyMatch(element -> element.endsWith("0=ocfl_1.0")));
+        assertTrue(checkDirForNamaste(targetDir));
 
         //migrate object into it
         final Path workingDir = tmpDir.resolve("working");
@@ -212,8 +216,8 @@ public class PicocliIT {
         //now check for a FOXML, which should show up in a previous version
         final var versions = ocflRepo.describeObject("example:1").getVersionMap().values();
         boolean foundFoxml = false;
-        for (VersionDetails v : versions) {
-            for (FileDetails f : v.getFiles()) {
+        for (final VersionDetails v : versions) {
+            for (final FileDetails f : v.getFiles()) {
                 if (f.getPath().equals("FOXML")) {
                     foundFoxml = true;
                     break;
@@ -266,7 +270,7 @@ public class PicocliIT {
 
         final int result = cmd.execute(args);
         assertEquals(0, result);
-        assertTrue(Files.list(targetDir).anyMatch(element -> element.endsWith("0=ocfl_1.0")));
+        assertTrue(checkDirForNamaste(targetDir));
         final Path baseDir = targetDir.resolve("5b5").resolve("62d").resolve("d69")
                 .resolve("5b562dd698f17e3198e007e6f77f9e48f20a556c6bae84e6fc8d98544831daa6");
         final File inventory = baseDir.resolve("inventory.json").toFile();


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3863

# What does this Pull Request do?
Tests in `PicocliIT` were matching against the namaste file `0=ocfl_1.0`. With fcrepo-storage-ocfl upgrading to ocfl-java 1.5.0 all newly migrated OCFL objects are version 1.1.

This modifies the test to instead grab the last part of the Path object (filename or directory), convert it to a String (otherwise it uses a Path match which is the whole filename) and match against `0=ocfl_1.`

# How should this be tested?

Tests pass

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? 
* Does this change add any new dependencies? 
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? 
* Could this change impact execution of existing code?

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
