### PR TITLE
Fcrepo 3880

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Set up JDK 11
-      uses: actions/setup-java@3
+      uses: actions/setup-java@v3
       with:
         java-version: 11
     - name: Cache Maven packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Set up JDK 11
-      uses: actions/setup-java@31
+      uses: actions/setup-java@3
       with:
         java-version: 11
     - name: Cache Maven packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: 11
+        distribution: temurin
     - name: Cache Maven packages
       uses: actions/cache@v3
       with:
@@ -48,6 +49,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: temurin
           server-id: sonatype-nexus-snapshots
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@31
       with:
         java-version: 11
     - name: Cache Maven packages
@@ -45,7 +45,7 @@ jobs:
       - name: Checkout fcrepo
         uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
           server-id: sonatype-nexus-snapshots

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,13 +21,13 @@ jobs:
     - name: Git support longpaths
       run: git config --global core.longpaths true
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
         java-version: 11
     - name: Cache Maven packages
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -43,7 +43,7 @@ jobs:
       - name: Git support longpaths
         run: git config --global core.longpaths true
       - name: Checkout fcrepo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
**Update GitHub actions to use node16 based actions instead of deprecated node12**
* * *

**JIRA Ticket**: https://fedora-repository.atlassian.net/jira/software/c/projects/FCREPO/issues/FCREPO-3880

# What does this Pull Request do?
Updates GitHub actions to use node16 based actions instead of deprecated node12

# How should this be tested?
Simply ensure github actions run to completion

# Interested parties
@fcrepo/committers
