### PR TITLE
Fcrepo 3878 - Migrate DC datastream as RDF properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Usage: migration-utils [-chrVx] [--debug] -a=<targetDir>
                              Note: this requires port 8080 to be free in order
                                for Prometheus to scrape metrics.
                                Default: false
+      --disable-dc           Disable creation of DC properties from DC datastreams
       --debug                Enables debug logging
 ```
 
@@ -194,8 +195,6 @@ java -jar target/migration-utils-6.0.0-SNAPSHOT-driver.jar --source-type=legacy 
 | purgeDatastream                    | audit:contentRemoval‡                           |
 
 † The `fedora3model` namespace is not a published namespace. It is a representation of the fcrepo 3 namespace `info:fedora/fedora-system:def/model`.
-
-‡ Not yet implemented
 
 **Note**: All fcrepo 3 DC (Dublin Core) datastream values are mapped as dcterms properties on the Object in fcrepo 6+. The same goes for any properties in the RELS-EXT and RELS-INT datastreams.
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ java -jar target/migration-utils-6.0.0-SNAPSHOT-driver.jar --source-type=legacy 
 
 † The `fedora3model` namespace is not a published namespace. It is a representation of the fcrepo 3 namespace `info:fedora/fedora-system:def/model`.
 
+‡ Not yet implemented
+
 **Note**: All fcrepo 3 DC (Dublin Core) datastream values are mapped as dcterms properties on the Object in fcrepo 6+. The same goes for any properties in the RELS-EXT and RELS-INT datastreams.
 
 

--- a/src/main/java/org/fcrepo/migration/PicocliMigrator.java
+++ b/src/main/java/org/fcrepo/migration/PicocliMigrator.java
@@ -157,7 +157,7 @@ public class PicocliMigrator implements Callable<Integer> {
     private boolean enableMetrics;
 
     @Option(names = {"--disable-dc"}, defaultValue = "false", showDefaultValue = ALWAYS, order = 36,
-            description = "Disable migrating DC datastream into RDF object properties. ") 
+            description = "Disable migrating DC datastream into RDF object properties. ")
     private boolean disableDc;
 
 

--- a/src/main/java/org/fcrepo/migration/PicocliMigrator.java
+++ b/src/main/java/org/fcrepo/migration/PicocliMigrator.java
@@ -156,6 +156,11 @@ public class PicocliMigrator implements Callable<Integer> {
                           "\nNote: this requires port 8080 to be free in order for Prometheus to scrape metrics.")
     private boolean enableMetrics;
 
+    @Option(names = {"--disable-dc"}, defaultValue = "false", showDefaultValue = ALWAYS, order = 36,
+            description = "Disable migrating DC datastream into RDF object properties. ") 
+    private boolean disableDc;
+
+
     @Option(names = {"--head-only", "-H"}, defaultValue = "false", showDefaultValue = ALWAYS, order = 35,
             description = "Migrate only the HEAD of each datastream")
     private boolean headOnly;
@@ -311,7 +316,7 @@ public class PicocliMigrator implements Callable<Integer> {
                         ocflSessionFactory, migrationType,
                         atomicResources ? ResourceMigrationType.ATOMIC : ResourceMigrationType.ARCHIVAL,
                         addExtensions, deleteInactive, foxmlFile,
-                        user, idPrefix, headOnly, disableChecksumValidation);
+                        user, idPrefix, headOnly, disableChecksumValidation, disableDc);
         final StreamingFedoraObjectHandler objectHandler = new ObjectAbstractionStreamingFedoraObjectHandler(
                 archiveGroupHandler);
 

--- a/src/main/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandler.java
+++ b/src/main/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandler.java
@@ -76,7 +76,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-import javax.xml.bind.JAXBException;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -309,11 +308,9 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
                         DC dc = new DC();
                         try {
                             dc = DC.parseDC(dv.getContent());
-                        } catch (final IOException e) {
-                            LOGGER.error("problem parsing DC record within: " + f6DsId);
-                            throw new UncheckedIOException(e);
-                        } catch (JAXBException e) {
-                            LOGGER.error("problem parsing DC within: " + f6DsId);
+                        } catch (Exception e) {
+                            throw new RuntimeException(String.format("Failed to parse DC XML in %s/%s",
+                                objectId,f6DsId), e);
                         }
 
                         final var model = ModelFactory.createDefaultModel();
@@ -325,7 +322,7 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
                                     NodeFactory.createLiteral(value, XSDDatatype.XSDstring));
                                 final Statement statement = model.asStatement(dcTriple);
                                 model.add(statement);
-                                LOGGER.info(dcTriple.toString());
+                                LOGGER.debug(dcTriple.toString());
                             }
                         }
 

--- a/src/main/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandler.java
+++ b/src/main/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandler.java
@@ -133,6 +133,7 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
     private final Detector mimeDetector;
     private final boolean headOnly;
     private final boolean disableChecksumValidation;
+    private final boolean disableDc;
 
     /**
      * Create an ArchiveGroupHandler,
@@ -156,6 +157,9 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
      * @param headOnly
      *        flag to enable head only migrations
      * @param disableChecksumValidation
+     *        disable Checksum validation
+     * @param disableDc
+     *        true if DC datastreams should not be migrated to RDF object properties
      */
     public ArchiveGroupHandler(final OcflObjectSessionFactory sessionFactory,
                                final MigrationType migrationType,
@@ -166,7 +170,8 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
                                final String user,
                                final String idPrefix,
                                final boolean headOnly,
-                               final boolean disableChecksumValidation) {
+                               final boolean disableChecksumValidation,
+                               final boolean disableDc) {
         this.sessionFactory = Preconditions.checkNotNull(sessionFactory, "sessionFactory cannot be null");
         this.migrationType = Preconditions.checkNotNull(migrationType, "migrationType cannot be null");
         this.resourceMigrationType = Preconditions.checkNotNull(resourceMigrationType,
@@ -178,6 +183,7 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
         this.idPrefix = idPrefix;
         this.headOnly = headOnly;
         this.disableChecksumValidation = disableChecksumValidation;
+        this.disableDc = disableDc;
         try {
             this.mimeDetector = new TikaConfig().getDetector();
         } catch (Exception e) {
@@ -299,7 +305,7 @@ public class ArchiveGroupHandler implements FedoraObjectVersionHandler {
                             .setContentTriples(descriptionTriples);
                     toWrite.add(f6DescId);
 
-                    if (DC_DS.equals(dsId)) {
+                    if (DC_DS.equals(dsId) && !disableDc) {
                         DC dc = new DC();
                         try {
                             dc = DC.parseDC(dv.getContent());

--- a/src/test/java/org/fcrepo/migration/InlineXmlIT.java
+++ b/src/test/java/org/fcrepo/migration/InlineXmlIT.java
@@ -29,7 +29,10 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Map;
-
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -81,6 +84,20 @@ public class InlineXmlIT {
         context = new ClassPathXmlApplicationContext(String.format("spring/%s-setup.xml", name));
         migrator = (Migrator) context.getBean("migrator");
         sessionFactory = (OcflObjectSessionFactory) context.getBean("ocflSessionFactory");
+    }
+
+    @Test
+    public void testDcProperties() throws Exception {
+        setup("inline-it");
+        migrator.run();
+        final var session = sessionFactory.newSession("info:fedora/fedora-system:ContentModel-3.0");
+        final var content = session.readContent("info:fedora/fedora-system:ContentModel-3.0");
+        final String contentText = new BufferedReader(
+            new InputStreamReader(content.getContentStream().get(), StandardCharsets.UTF_8))
+                .lines()
+                .collect(Collectors.joining("\n"));
+        assertTrue(contentText.contains("<info:fedora/fedora-system:ContentModel-3.0> " +
+                    "<http://purl.org/dc/elements/1.1/identifier> \"fedora-system:ContentModel-3.0\""));
     }
 
     @Test

--- a/src/test/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandlerTest.java
+++ b/src/test/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandlerTest.java
@@ -1245,11 +1245,11 @@ public class ArchiveGroupHandlerTest {
         if (migrationType == MigrationType.PLAIN_OCFL) {
             return new ArchiveGroupHandler(plainSessionFactory, migrationType, resourceMigrationType,
                                            addExtensions, deleteInactive,
-                                           false, USER, "info:fedora/", headOnly, false);
+                                           false, USER, "info:fedora/", headOnly, false, false);
         } else {
             return new ArchiveGroupHandler(sessionFactory, migrationType, resourceMigrationType,
                                            addExtensions, deleteInactive, false, USER,
-                                           "info:fedora/", headOnly, false);
+                                           "info:fedora/", headOnly, false, false);
         }
     }
 

--- a/src/test/java/org/fcrepo/migration/pidlist/HeadOnlyIT.java
+++ b/src/test/java/org/fcrepo/migration/pidlist/HeadOnlyIT.java
@@ -41,6 +41,7 @@ public class HeadOnlyIT {
     private final String idPrefix = "info:fedora/";
     private final String testPid = idPrefix + "example:1";
     private final boolean disableChecksum = false;
+    private final boolean disableDc = false;
 
     private final DigestAlgorithm digestAlgorithm = DigestAlgorithm.sha512;
     private final MigrationType migrationType = MigrationType.FEDORA_OCFL;
@@ -137,7 +138,7 @@ public class HeadOnlyIT {
         final ResourceMigrationType resourceMigrationType = ResourceMigrationType.ARCHIVAL;
         return new ArchiveGroupHandler(ocflObjectSessionFactory, migrationType, resourceMigrationType,
                                        datastreamExtensions, deleteInactive, foxmlFile, user, idPrefix,
-                                       headOnly, disableChecksum);
+                                       headOnly, disableChecksum, disableDc);
     }
 
     private OcflRepository repository() {

--- a/src/test/resources/spring/inline-disabled-it-setup.xml
+++ b/src/test/resources/spring/inline-disabled-it-setup.xml
@@ -17,11 +17,11 @@
         <constructor-arg name="localFedoraServer" ref="localFedoraServer" />
         <property name="fetcher" ref="httpClientURLFetcher"/>
     </bean>
-    
+
     <bean id="akubraIDResolver" class="org.fcrepo.migration.foxml.AkubraFSIDResolver" lazy-init="true">
         <constructor-arg name="dsRoot" type="java.io.File" ref="datastreamStore"/>
     </bean>
-    
+
 
     <!-- Set foxml.dir.objects or CHANGE THIS TO YOUR FEDORA 3 OBJECTS DIRECTORY -->
     <bean id="objectStore" class="java.io.File">
@@ -56,6 +56,7 @@
         <constructor-arg name="idPrefix" value="info:fedora/" />
         <constructor-arg name="headOnly" value="false"/>
         <constructor-arg name="disableChecksumValidation" value="false" />
+        <constructor-arg name="disableDc" value="false" />
     </bean>
 
     <bean id="ocflSessionFactory" class="org.fcrepo.migration.OcflSessionFactoryFactoryBean">

--- a/src/test/resources/spring/inline-invalid-it-setup.xml
+++ b/src/test/resources/spring/inline-invalid-it-setup.xml
@@ -60,6 +60,7 @@
         <constructor-arg name="idPrefix" value="info:fedora/" />
         <constructor-arg name="headOnly" value="false"/>
         <constructor-arg name="disableChecksumValidation" value="false" />
+        <constructor-arg name="disableDc" value="false" />
     </bean>
 
     <bean id="ocflSessionFactory" class="org.fcrepo.migration.OcflSessionFactoryFactoryBean">

--- a/src/test/resources/spring/inline-it-setup.xml
+++ b/src/test/resources/spring/inline-it-setup.xml
@@ -60,6 +60,7 @@
         <constructor-arg name="idPrefix" value="info:fedora/" />
         <constructor-arg name="headOnly" value="false"/>
         <constructor-arg name="disableChecksumValidation" value="false" />
+        <constructor-arg name="disableDc" value="false" />
     </bean>
 
     <bean id="ocflSessionFactory" class="org.fcrepo.migration.OcflSessionFactoryFactoryBean">

--- a/src/test/resources/spring/ocfl-pid-it-setup.xml
+++ b/src/test/resources/spring/ocfl-pid-it-setup.xml
@@ -82,6 +82,7 @@
         <constructor-arg name="idPrefix" value="info:fedora/" />
         <constructor-arg name="headOnly" value="false"/>
         <constructor-arg name="disableChecksumValidation" value="false" />
+        <constructor-arg name="disableDc" value="false" />
     </bean>
 
     <bean id="ocflSessionFactory" class="org.fcrepo.migration.OcflSessionFactoryFactoryBean">

--- a/src/test/resources/spring/ocfl-user-it-setup.xml
+++ b/src/test/resources/spring/ocfl-user-it-setup.xml
@@ -82,6 +82,7 @@
         <constructor-arg name="idPrefix" value="info:fedora/" />
         <constructor-arg name="headOnly" value="false"/>
         <constructor-arg name="disableChecksumValidation" value="false" />
+        <constructor-arg name="disableDc" value="false" />
     </bean>
 
     <bean id="ocflSessionFactory" class="org.fcrepo.migration.OcflSessionFactoryFactoryBean">


### PR DESCRIPTION
**Migrate DC datastream as RDF properties**
* * *

**JIRA Ticket**: https://fedora-repository.atlassian.net/jira/software/c/projects/FCREPO/issues/FCREPO-3878

# What does this Pull Request do?
Adds the default feature of indexing DC datastreams into object properties where they exist. This feature can be turned off with a commandline argument ```--disable-dc``` 

# How should this be tested?

Run a migration on fedora3 objects with and without DC datastreams and test for the existance of the properties in the resulting OCFL ntriples container files

# Additional Notes:

Example:
* Does this change require documentation to be updated? 
* Does this change add any new dependencies? 
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? 
* Could this change impact execution of existing code?

# Interested parties
@fcrepo/committers
