### PR TITLE
Add full date to log messages

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -16,7 +16,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%p %d{HH:mm:ss.SSS} \(%c{0}\) %m%n</pattern>
+            <pattern>%p %d{ISO8601} \(%c{0}\) %m%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-4005

# What does this Pull Request do?
Adds the full ISO-8601 date to log messages




# How should this be tested?

Running a migration before this PR:
```
> java -jar target/migration-utils-6.6.0-SNAPSHOT-driver.jar -t akubra -d ../testing_helper/fedora_3_test/dsDir/ -o ../testing_helper/fedora_3_test/objectDir -a ../testing_helper/migration_output/output -i ../testing_helper/migration_output/working
INFO 11:13:51.062 (InternalIDResolver) Building an index of all the datastreams in "../testing_helper/fedora_3_test/dsDir"...
INFO 11:13:51.543 (Migrator) Processing "example:1"...
WARN 11:13:51.665 (ArchiveGroupHandler) info:fedora/example:1/RELS-EXT: missing/invalid digest. Writing resource & continuing.
```
Running a migration with this PR
```
> java -jar target/migration-utils-6.6.0-SNAPSHOT-driver.jar -t akubra -d ../testing_helper/fedora_3_test/dsDir/ -o ../testing_helper/fedora_3_test/objectDir -a ../testing_helper/migration_output/output -i ../testing_helper/migration_output/working
INFO 2025-04-17 11:10:00,099 (InternalIDResolver) Building an index of all the datastreams in "../testing_helper/fedora_3_test/dsDir"...
INFO 2025-04-17 11:10:00,644 (Migrator) Processing "example:1"...
WARN 2025-04-17 11:10:00,786 (ArchiveGroupHandler) info:fedora/example:1/RELS-EXT: missing/invalid digest. Writing resource & continuing.
```


# Additional Notes:


# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo-exts/committers
