### PR TITLE
Enable Codecov reporting and raise test coverage above 90%

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,10 +36,10 @@ jobs:
     - name: Build with Maven
       run: mvn -B -U clean install
     - name: Upload coverage to Codecov
-      if: matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: ${{ matrix.os }}
   deploy:
     if: github.ref == 'refs/heads/main'
     needs: [build]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
     - name: Build with Maven
       run: mvn -B -U clean install org.jacoco:jacoco-maven-plugin:0.8.12:report
     - name: Upload coverage to Codecov
+      if: matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
     - name: Build with Maven
-      run: mvn -B -U clean install org.jacoco:jacoco-maven-plugin:0.8.12:report
+      run: mvn -B -U clean install
     - name: Upload coverage to Codecov
       if: matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v5

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Migration Utilities [![Build Status](https://github.com/fcrepo-exts/migration-utils/workflows/Build/badge.svg)](https://github.com/fcrepo-exts/migration-utils/actions)
+# Migration Utilities [![Build Status](https://github.com/fcrepo-exts/migration-utils/workflows/Build/badge.svg)](https://github.com/fcrepo-exts/migration-utils/actions) [![codecov](https://codecov.io/gh/fcrepo-exts/migration-utils/branch/main/graph/badge.svg)](https://codecov.io/gh/fcrepo-exts/migration-utils)
 A framework to support migration of data from Fedora 3 to Fedora 6 repositories
 
 ## Overview

--- a/pom.xml
+++ b/pom.xml
@@ -326,6 +326,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.0.0-M3</version>
         <configuration>
+          <argLine>@{argLine} -Xms512m -Xmx1024m</argLine>
           <systemPropertyVariables>
             <test.output.dir>${project.build.directory}</test.output.dir>
           </systemPropertyVariables>
@@ -334,6 +335,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <argLine>@{failsafeArgLine} -Xms512m -Xmx1024m</argLine>
+        </configuration>
         <executions>
           <execution>
             <id>perform-it</id>
@@ -395,9 +399,33 @@
             <goals><goal>prepare-agent</goal></goals>
           </execution>
           <execution>
+            <id>prepare-agent-integration</id>
+            <goals><goal>prepare-agent-integration</goal></goals>
+            <configuration>
+              <propertyName>failsafeArgLine</propertyName>
+            </configuration>
+          </execution>
+          <execution>
+            <id>merge-results</id>
+            <phase>post-integration-test</phase>
+            <goals><goal>merge</goal></goals>
+            <configuration>
+              <fileSets>
+                <fileSet>
+                  <directory>${project.build.directory}</directory>
+                  <includes><include>*.exec</include></includes>
+                </fileSet>
+              </fileSets>
+              <destFile>${project.build.directory}/jacoco-merged.exec</destFile>
+            </configuration>
+          </execution>
+          <execution>
             <id>jacoco-report</id>
-            <phase>prepare-package</phase>
+            <phase>verify</phase>
             <goals><goal>report</goal></goals>
+            <configuration>
+              <dataFile>${project.build.directory}/jacoco-merged.exec</dataFile>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/src/test/java/org/fcrepo/migration/MigratorTest.java
+++ b/src/test/java/org/fcrepo/migration/MigratorTest.java
@@ -1,8 +1,7 @@
-/**
+/*
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree.
- *
  */
 package org.fcrepo.migration;
 

--- a/src/test/java/org/fcrepo/migration/MigratorTest.java
+++ b/src/test/java/org/fcrepo/migration/MigratorTest.java
@@ -25,7 +25,7 @@ import org.mockito.junit.MockitoJUnitRunner;
  * Unit tests for {@link Migrator#run()} covering limit handling, pid filtering
  * and error handling behaviour.
  *
- * @author Claude
+ * @author Dan Field
  */
 @RunWith(MockitoJUnitRunner.class)
 public class MigratorTest {

--- a/src/test/java/org/fcrepo/migration/MigratorTest.java
+++ b/src/test/java/org/fcrepo/migration/MigratorTest.java
@@ -1,0 +1,207 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ *
+ */
+package org.fcrepo.migration;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.fcrepo.migration.pidlist.ResumePidListManager;
+import org.fcrepo.migration.pidlist.UserProvidedPidListManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Unit tests for {@link Migrator#run()} covering limit handling, pid filtering
+ * and error handling behaviour.
+ *
+ * @author Claude
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class MigratorTest {
+
+    @Mock
+    private ObjectSource source;
+
+    @Mock
+    private StreamingFedoraObjectHandler handler;
+
+    @Mock
+    private ResumePidListManager resumePidListManager;
+
+    @Mock
+    private UserProvidedPidListManager userProvidedPidListManager;
+
+    private Migrator migrator;
+
+    @Before
+    public void setup() {
+        migrator = new Migrator();
+        migrator.setHandler(handler);
+        migrator.setSource(source);
+    }
+
+    private FedoraObjectProcessor processor(final String pid) {
+        final ObjectInfo info = Mockito.mock(ObjectInfo.class);
+        Mockito.lenient().when(info.getPid()).thenReturn(pid);
+        final FedoraObjectProcessor processor = Mockito.mock(FedoraObjectProcessor.class);
+        Mockito.lenient().when(processor.getObjectInfo()).thenReturn(info);
+        return processor;
+    }
+
+    @SafeVarargs
+    private final void sourceReturns(final FedoraObjectProcessor... processors) {
+        Mockito.when(source.iterator()).thenReturn(Arrays.asList(processors).iterator());
+    }
+
+    @Test
+    public void processesAllObjects() throws Exception {
+        final var p1 = processor("obj:1");
+        final var p2 = processor("obj:2");
+        sourceReturns(p1, p2);
+
+        migrator.run();
+
+        Mockito.verify(p1).processObject(handler);
+        Mockito.verify(p2).processObject(handler);
+        Mockito.verify(p1).close();
+        Mockito.verify(p2).close();
+    }
+
+    @Test
+    public void respectsLimit() throws Exception {
+        final var p1 = processor("obj:1");
+        final var p2 = processor("obj:2");
+        sourceReturns(p1, p2);
+        migrator.setLimit(1);
+
+        migrator.run();
+
+        Mockito.verify(p1).processObject(handler);
+        Mockito.verify(p2, Mockito.never()).processObject(handler);
+    }
+
+    @Test
+    public void skipsObjectsWithNullPid() throws Exception {
+        final var p1 = processor(null);
+        sourceReturns(p1);
+
+        migrator.run();
+
+        Mockito.verify(p1, Mockito.never()).processObject(handler);
+    }
+
+    @Test
+    public void continueOnErrorSwallowsProcessingFailure() throws Exception {
+        final var p1 = processor("obj:1");
+        final var p2 = processor("obj:2");
+        Mockito.doThrow(new XMLStreamException("boom")).when(p1).processObject(handler);
+        sourceReturns(p1, p2);
+        migrator.setContinueOnError(true);
+
+        migrator.run();
+
+        Mockito.verify(p2).processObject(handler);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void processingFailureThrowsWhenNotContinuing() throws Exception {
+        final var p1 = processor("obj:1");
+        Mockito.doThrow(new XMLStreamException("boom")).when(p1).processObject(handler);
+        sourceReturns(p1);
+
+        migrator.run();
+    }
+
+    @Test
+    public void continueOnErrorSwallowsUnreadableObject() throws Exception {
+        @SuppressWarnings("unchecked")
+        final Iterator<FedoraObjectProcessor> iterator = Mockito.mock(Iterator.class);
+        Mockito.when(iterator.hasNext()).thenReturn(true, false);
+        Mockito.when(iterator.next()).thenThrow(new RuntimeException("unreadable"));
+        Mockito.when(source.iterator()).thenReturn(iterator);
+        migrator.setContinueOnError(true);
+
+        migrator.run();
+
+        Mockito.verify(iterator, Mockito.times(2)).hasNext();
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void unreadableObjectThrowsWhenNotContinuing() throws Exception {
+        @SuppressWarnings("unchecked")
+        final Iterator<FedoraObjectProcessor> iterator = Mockito.mock(Iterator.class);
+        Mockito.when(iterator.hasNext()).thenReturn(true, false);
+        Mockito.when(iterator.next()).thenThrow(new RuntimeException("unreadable"));
+        Mockito.when(source.iterator()).thenReturn(iterator);
+
+        migrator.run();
+    }
+
+    @Test
+    public void stopsWhenUserProvidedListFinished() throws Exception {
+        final var p1 = processor("obj:1");
+        final var p2 = processor("obj:2");
+        sourceReturns(p1, p2);
+        migrator.setUserProvidedPidListManager(userProvidedPidListManager);
+        Mockito.when(userProvidedPidListManager.accept(Mockito.anyString())).thenReturn(true);
+        Mockito.when(userProvidedPidListManager.finishedProcessingAllPids()).thenReturn(true);
+
+        migrator.run();
+
+        Mockito.verify(p1).processObject(handler);
+        Mockito.verify(p2, Mockito.never()).processObject(handler);
+    }
+
+    @Test
+    public void skipsPidRejectedByUserProvidedList() throws Exception {
+        final var p1 = processor("obj:1");
+        sourceReturns(p1);
+        migrator.setUserProvidedPidListManager(userProvidedPidListManager);
+        Mockito.when(userProvidedPidListManager.accept("obj:1")).thenReturn(false);
+        Mockito.when(userProvidedPidListManager.finishedProcessingAllPids()).thenReturn(false);
+
+        migrator.run();
+
+        Mockito.verify(p1, Mockito.never()).processObject(handler);
+    }
+
+    @Test
+    public void skipsPidRejectedByResumeList() throws Exception {
+        final var p1 = processor("obj:1");
+        sourceReturns(p1);
+        migrator.setResumePidListManager(resumePidListManager);
+        Mockito.when(resumePidListManager.accept("obj:1")).thenReturn(false);
+
+        migrator.run();
+
+        Mockito.verify(p1, Mockito.never()).processObject(handler);
+    }
+
+    @Test
+    public void mainWithoutConfigPrintsHelp() throws Exception {
+        // No arguments -> the usage/help text is printed and the method returns without error.
+        Migrator.main(new String[] {});
+    }
+
+    @Test
+    public void constructorWiresSourceAndHandler() throws Exception {
+        final var p1 = processor("obj:1");
+        Mockito.when(source.iterator()).thenReturn(Collections.singletonList(p1).iterator());
+        final var constructed = new Migrator(source, handler);
+
+        constructed.run();
+
+        Mockito.verify(p1).processObject(handler);
+    }
+}

--- a/src/test/java/org/fcrepo/migration/PicocliMigratorTest.java
+++ b/src/test/java/org/fcrepo/migration/PicocliMigratorTest.java
@@ -1,8 +1,7 @@
-/**
+/*
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree.
- *
  */
 package org.fcrepo.migration;
 

--- a/src/test/java/org/fcrepo/migration/PicocliMigratorTest.java
+++ b/src/test/java/org/fcrepo/migration/PicocliMigratorTest.java
@@ -1,0 +1,84 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ *
+ */
+package org.fcrepo.migration;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Drives {@link PicocliMigrator#main(String[])} through failure paths to exercise the
+ * command wiring, converter and execution exception handler.
+ *
+ * @author Claude
+ */
+public class PicocliMigratorTest {
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+
+    private PrintStream originalErr;
+    private ByteArrayOutputStream err;
+
+    @Before
+    public void captureErr() {
+        originalErr = System.err;
+        err = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(err, true, StandardCharsets.UTF_8));
+    }
+
+    @After
+    public void restoreErr() {
+        System.setErr(originalErr);
+    }
+
+    private String errText() {
+        return new String(err.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void invalidAlgorithmIsHandledWithDebug() {
+        PicocliMigrator.main(new String[] {
+            "-t", "legacy",
+            "-a", tempDir.getRoot().getAbsolutePath(),
+            "--algorithm", "not-an-algorithm",
+            "--debug"
+        });
+
+        assertTrue(errText().contains("Invalid algorithm"));
+    }
+
+    @Test
+    public void invalidAlgorithmIsHandledWithoutDebug() {
+        PicocliMigrator.main(new String[] {
+            "-t", "legacy",
+            "-a", tempDir.getRoot().getAbsolutePath(),
+            "--algorithm", "not-an-algorithm"
+        });
+
+        assertTrue(errText().contains("Invalid algorithm"));
+    }
+
+    @Test
+    public void unknownSourceTypeIsRejected() {
+        PicocliMigrator.main(new String[] {
+            "-t", "bogus",
+            "-a", tempDir.getRoot().getAbsolutePath()
+        });
+
+        // The custom converter throws while parsing an unknown source type.
+        assertTrue(errText().length() > 0);
+    }
+}

--- a/src/test/java/org/fcrepo/migration/PicocliMigratorTest.java
+++ b/src/test/java/org/fcrepo/migration/PicocliMigratorTest.java
@@ -22,7 +22,7 @@ import org.junit.rules.TemporaryFolder;
  * Drives {@link PicocliMigrator#main(String[])} through failure paths to exercise the
  * command wiring, converter and execution exception handler.
  *
- * @author Claude
+ * @author Dan Field
  */
 public class PicocliMigratorTest {
 

--- a/src/test/java/org/fcrepo/migration/foxml/DCTest.java
+++ b/src/test/java/org/fcrepo/migration/foxml/DCTest.java
@@ -44,6 +44,14 @@ public class DCTest {
         }
     }
 
+    @Test(expected = RuntimeException.class)
+    public void testUnknownUriThrows() {
+        dcSample1.getValuesForURI(DC.DC_NS + "notADcElement");
+    }
 
+    @Test
+    public void testNullFieldReturnsNull() {
+        Assert.assertNull(new DC().getValuesForURI(DC.DC_NS + "title"));
+    }
 
 }

--- a/src/test/java/org/fcrepo/migration/foxml/DirectoryScanningIDResolverTest.java
+++ b/src/test/java/org/fcrepo/migration/foxml/DirectoryScanningIDResolverTest.java
@@ -20,7 +20,7 @@ import org.junit.rules.TemporaryFolder;
  * Exercises the shared indexing and lookup behaviour of {@link DirectoryScanningIDResolver}
  * via a concrete subclass.
  *
- * @author Claude
+ * @author Dan Field
  */
 public class DirectoryScanningIDResolverTest {
 

--- a/src/test/java/org/fcrepo/migration/foxml/DirectoryScanningIDResolverTest.java
+++ b/src/test/java/org/fcrepo/migration/foxml/DirectoryScanningIDResolverTest.java
@@ -1,8 +1,7 @@
-/**
+/*
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree.
- *
  */
 package org.fcrepo.migration.foxml;
 

--- a/src/test/java/org/fcrepo/migration/foxml/DirectoryScanningIDResolverTest.java
+++ b/src/test/java/org/fcrepo/migration/foxml/DirectoryScanningIDResolverTest.java
@@ -1,0 +1,106 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ *
+ */
+package org.fcrepo.migration.foxml;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Exercises the shared indexing and lookup behaviour of {@link DirectoryScanningIDResolver}
+ * via a concrete subclass.
+ *
+ * @author Claude
+ */
+public class DirectoryScanningIDResolverTest {
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+
+    /**
+     * Resolver that treats each file's name as its internal id.
+     */
+    private static class NameResolver extends DirectoryScanningIDResolver {
+        NameResolver(final File indexDir, final File dsRoot) throws IOException {
+            super(indexDir, dsRoot);
+        }
+
+        @Override
+        protected String getInternalIdForFile(final File f) {
+            return f.getName();
+        }
+    }
+
+    /**
+     * Resolver that maps every file to the same id, to force an ambiguous lookup.
+     */
+    private static class ConstantResolver extends DirectoryScanningIDResolver {
+        ConstantResolver(final File indexDir, final File dsRoot) throws IOException {
+            super(indexDir, dsRoot);
+        }
+
+        @Override
+        protected String getInternalIdForFile(final File f) {
+            return "dup";
+        }
+    }
+
+    private File datastreamTree() throws IOException {
+        final File dsRoot = tempDir.newFolder("datastreams");
+        final File sub = new File(dsRoot, "sub");
+        sub.mkdir();
+        new File(sub, "fileA").createNewFile();
+        new File(dsRoot, "fileB").createNewFile();
+        return dsRoot;
+    }
+
+    @Test
+    public void resolvesIndexedIdAndReportsMissing() throws IOException {
+        // A null index directory triggers the temporary-index branch.
+        final NameResolver resolver = new NameResolver(null, datastreamTree());
+        try {
+            assertNotNull(resolver.resolveInternalID("fileA"));
+            assertThrows(RuntimeException.class, () -> resolver.resolveInternalID("does-not-exist"));
+        } finally {
+            resolver.close();
+        }
+    }
+
+    @Test
+    public void ambiguousIdThrows() throws IOException {
+        final File indexDir = tempDir.newFolder("index-dup");
+        final ConstantResolver resolver = new ConstantResolver(indexDir, datastreamTree());
+        try {
+            assertThrows(IllegalStateException.class, () -> resolver.resolveInternalID("dup"));
+        } finally {
+            resolver.close();
+        }
+    }
+
+    @Test
+    public void reusesExistingIndex() throws IOException {
+        final File indexDir = tempDir.newFolder("index-cache");
+        final File dsRoot = datastreamTree();
+
+        final NameResolver first = new NameResolver(indexDir, dsRoot);
+        first.close();
+
+        // Second construction finds a populated index directory and reuses it.
+        final NameResolver second = new NameResolver(indexDir, dsRoot);
+        try {
+            assertNotNull(second.resolveInternalID("fileB"));
+        } finally {
+            second.close();
+        }
+    }
+}

--- a/src/test/java/org/fcrepo/migration/foxml/FoxmlDirectoryDFSIteratorTreeTest.java
+++ b/src/test/java/org/fcrepo/migration/foxml/FoxmlDirectoryDFSIteratorTreeTest.java
@@ -1,8 +1,7 @@
-/**
+/*
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree.
- *
  */
 package org.fcrepo.migration.foxml;
 

--- a/src/test/java/org/fcrepo/migration/foxml/FoxmlDirectoryDFSIteratorTreeTest.java
+++ b/src/test/java/org/fcrepo/migration/foxml/FoxmlDirectoryDFSIteratorTreeTest.java
@@ -22,7 +22,7 @@ import org.junit.rules.TemporaryFolder;
  * Exercises the depth-first traversal of {@link FoxmlDirectoryDFSIterator} over a real
  * directory tree.
  *
- * @author Claude
+ * @author Dan Field
  */
 public class FoxmlDirectoryDFSIteratorTreeTest {
 

--- a/src/test/java/org/fcrepo/migration/foxml/FoxmlDirectoryDFSIteratorTreeTest.java
+++ b/src/test/java/org/fcrepo/migration/foxml/FoxmlDirectoryDFSIteratorTreeTest.java
@@ -1,0 +1,63 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ *
+ */
+package org.fcrepo.migration.foxml;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+import org.apache.commons.io.filefilter.RegexFileFilter;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Exercises the depth-first traversal of {@link FoxmlDirectoryDFSIterator} over a real
+ * directory tree.
+ *
+ * @author Claude
+ */
+public class FoxmlDirectoryDFSIteratorTreeTest {
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+
+    private static final Pattern MATCH_NONE = Pattern.compile("match-nothing-xyz");
+
+    @Test
+    public void descendsDirectoriesWhenFilterRejectsEverything() throws IOException {
+        final File root = tempDir.newFolder("root");
+        final File sub = new File(root, "sub");
+        sub.mkdir();
+        new File(sub, "child.txt").createNewFile();
+
+        final var iterator =
+                new FoxmlDirectoryDFSIterator(root, null, null, new RegexFileFilter(MATCH_NONE));
+
+        // Walking the whole tree (descending into "sub" and popping back) yields no matches.
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void nextThrowsWhenExhausted() throws IOException {
+        final File root = tempDir.newFolder("empty");
+        final var iterator =
+                new FoxmlDirectoryDFSIterator(root, null, null, new RegexFileFilter(Pattern.compile(".*")));
+        assertThrows(IllegalStateException.class, iterator::next);
+    }
+
+    @Test
+    public void removeIsUnsupported() throws IOException {
+        final File root = tempDir.newFolder("root");
+        final var iterator =
+                new FoxmlDirectoryDFSIterator(root, null, null, new RegexFileFilter(Pattern.compile(".*")));
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
+    }
+}

--- a/src/test/java/org/fcrepo/migration/foxml/NamespacePrefixMapperTest.java
+++ b/src/test/java/org/fcrepo/migration/foxml/NamespacePrefixMapperTest.java
@@ -1,8 +1,7 @@
-/**
+/*
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree.
- *
  */
 package org.fcrepo.migration.foxml;
 

--- a/src/test/java/org/fcrepo/migration/foxml/NamespacePrefixMapperTest.java
+++ b/src/test/java/org/fcrepo/migration/foxml/NamespacePrefixMapperTest.java
@@ -17,7 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * @author Claude
+ * @author Dan Field
  */
 public class NamespacePrefixMapperTest {
 

--- a/src/test/java/org/fcrepo/migration/foxml/NamespacePrefixMapperTest.java
+++ b/src/test/java/org/fcrepo/migration/foxml/NamespacePrefixMapperTest.java
@@ -1,0 +1,53 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ *
+ */
+package org.fcrepo.migration.foxml;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import org.apache.jena.update.UpdateRequest;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Claude
+ */
+public class NamespacePrefixMapperTest {
+
+    private File namespaceFile;
+
+    @Before
+    public void setup() throws IOException {
+        namespaceFile = File.createTempFile("namespaces", ".properties");
+        namespaceFile.deleteOnExit();
+        Files.write(namespaceFile.toPath(),
+                ("dc=http://purl.org/dc/elements/1.1/\n"
+                        + "fedora=info:fedora/fedora-system:def/relations-external#\n")
+                        .getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testSetPrefixesAppliesAllEntries() throws IOException {
+        final NamespacePrefixMapper mapper = new NamespacePrefixMapper(namespaceFile);
+        final UpdateRequest updateRequest = new UpdateRequest();
+
+        mapper.setPrefixes(updateRequest);
+
+        Assert.assertEquals("http://purl.org/dc/elements/1.1/",
+                updateRequest.getPrefixMapping().getNsPrefixURI("dc"));
+        Assert.assertEquals("info:fedora/fedora-system:def/relations-external#",
+                updateRequest.getPrefixMapping().getNsPrefixURI("fedora"));
+    }
+
+    @Test(expected = IOException.class)
+    public void testMissingFileThrows() throws IOException {
+        new NamespacePrefixMapper(new File("does-not-exist-12345.properties"));
+    }
+}

--- a/src/test/java/org/fcrepo/migration/foxml/ObjectSourceFileFilterTest.java
+++ b/src/test/java/org/fcrepo/migration/foxml/ObjectSourceFileFilterTest.java
@@ -1,8 +1,7 @@
-/**
+/*
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree.
- *
  */
 package org.fcrepo.migration.foxml;
 

--- a/src/test/java/org/fcrepo/migration/foxml/ObjectSourceFileFilterTest.java
+++ b/src/test/java/org/fcrepo/migration/foxml/ObjectSourceFileFilterTest.java
@@ -19,7 +19,7 @@ import org.junit.rules.TemporaryFolder;
 /**
  * Covers the {@code setFileFilter} configuration hooks of the directory-based object sources.
  *
- * @author Claude
+ * @author Dan Field
  */
 public class ObjectSourceFileFilterTest {
 

--- a/src/test/java/org/fcrepo/migration/foxml/ObjectSourceFileFilterTest.java
+++ b/src/test/java/org/fcrepo/migration/foxml/ObjectSourceFileFilterTest.java
@@ -1,0 +1,46 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ *
+ */
+package org.fcrepo.migration.foxml;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+import org.apache.commons.io.filefilter.RegexFileFilter;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Covers the {@code setFileFilter} configuration hooks of the directory-based object sources.
+ *
+ * @author Claude
+ */
+public class ObjectSourceFileFilterTest {
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+
+    private static final RegexFileFilter FILTER = new RegexFileFilter(Pattern.compile(".*"));
+
+    @Test
+    public void nativeSourceAcceptsFileFilter() throws IOException {
+        final var source =
+                new NativeFoxmlDirectoryObjectSource(tempDir.newFolder("native"), null, "localhost:8080");
+        source.setFileFilter(FILTER);
+        assertNotNull(source);
+    }
+
+    @Test
+    public void exportedSourceAcceptsFileFilter() throws IOException {
+        final var source =
+                new ArchiveExportedFoxmlDirectoryObjectSource(tempDir.newFolder("exported"), "localhost:8080");
+        source.setFileFilter(FILTER);
+        assertNotNull(source);
+    }
+}

--- a/src/test/java/org/fcrepo/migration/handlers/ConsoleLoggingStreamingFedoraObjectHandlerTest.java
+++ b/src/test/java/org/fcrepo/migration/handlers/ConsoleLoggingStreamingFedoraObjectHandlerTest.java
@@ -1,8 +1,7 @@
-/**
+/*
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree.
- *
  */
 package org.fcrepo.migration.handlers;
 

--- a/src/test/java/org/fcrepo/migration/handlers/ConsoleLoggingStreamingFedoraObjectHandlerTest.java
+++ b/src/test/java/org/fcrepo/migration/handlers/ConsoleLoggingStreamingFedoraObjectHandlerTest.java
@@ -1,0 +1,75 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ *
+ */
+package org.fcrepo.migration.handlers;
+
+import java.util.Arrays;
+
+import org.fcrepo.migration.DatastreamInfo;
+import org.fcrepo.migration.DatastreamVersion;
+import org.fcrepo.migration.ObjectInfo;
+import org.fcrepo.migration.ObjectProperties;
+import org.fcrepo.migration.ObjectProperty;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Exercises every callback of the console logging handler to ensure the
+ * (side-effect only) logging paths run without error.
+ *
+ * @author Claude
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ConsoleLoggingStreamingFedoraObjectHandlerTest {
+
+    @Mock
+    private ObjectInfo objectInfo;
+
+    @Mock
+    private ObjectProperties objectProperties;
+
+    @Mock
+    private ObjectProperty objectProperty;
+
+    @Mock
+    private DatastreamVersion datastreamVersion;
+
+    @Mock
+    private DatastreamInfo datastreamInfo;
+
+    private ConsoleLoggingStreamingFedoraObjectHandler handler;
+
+    @Before
+    public void setup() {
+        handler = new ConsoleLoggingStreamingFedoraObjectHandler();
+        Mockito.when(objectInfo.getPid()).thenReturn("object:1");
+    }
+
+    @Test
+    public void testFullLifecycle() {
+        Mockito.when(objectProperty.getName()).thenReturn("info:fedora/fedora-system:def/model#state");
+        Mockito.when(objectProperty.getValue()).thenReturn("Active");
+        Mockito.doReturn(Arrays.asList(objectProperty)).when(objectProperties).listProperties();
+        Mockito.when(datastreamInfo.getDatastreamId()).thenReturn("DS1");
+        Mockito.when(datastreamVersion.getDatastreamInfo()).thenReturn(datastreamInfo);
+        Mockito.when(datastreamVersion.getVersionId()).thenReturn("DS1.0");
+
+        handler.beginObject(objectInfo);
+        handler.processObjectProperties(objectProperties);
+        handler.processDatastreamVersion(datastreamVersion);
+        handler.completeObject(objectInfo);
+    }
+
+    @Test
+    public void testAbortObject() {
+        handler.beginObject(objectInfo);
+        handler.abortObject(objectInfo);
+    }
+}

--- a/src/test/java/org/fcrepo/migration/handlers/ConsoleLoggingStreamingFedoraObjectHandlerTest.java
+++ b/src/test/java/org/fcrepo/migration/handlers/ConsoleLoggingStreamingFedoraObjectHandlerTest.java
@@ -24,7 +24,7 @@ import org.mockito.junit.MockitoJUnitRunner;
  * Exercises every callback of the console logging handler to ensure the
  * (side-effect only) logging paths run without error.
  *
- * @author Claude
+ * @author Dan Field
  */
 @RunWith(MockitoJUnitRunner.class)
 public class ConsoleLoggingStreamingFedoraObjectHandlerTest {

--- a/src/test/java/org/fcrepo/migration/handlers/ObjectAbstractionStreamingFedoraObjectHandlerTest.java
+++ b/src/test/java/org/fcrepo/migration/handlers/ObjectAbstractionStreamingFedoraObjectHandlerTest.java
@@ -1,8 +1,7 @@
-/**
+/*
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree.
- *
  */
 package org.fcrepo.migration.handlers;
 

--- a/src/test/java/org/fcrepo/migration/handlers/ObjectAbstractionStreamingFedoraObjectHandlerTest.java
+++ b/src/test/java/org/fcrepo/migration/handlers/ObjectAbstractionStreamingFedoraObjectHandlerTest.java
@@ -1,0 +1,117 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ *
+ */
+package org.fcrepo.migration.handlers;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.fcrepo.migration.DatastreamInfo;
+import org.fcrepo.migration.DatastreamVersion;
+import org.fcrepo.migration.FedoraObjectVersionHandler;
+import org.fcrepo.migration.ObjectInfo;
+import org.fcrepo.migration.ObjectProperties;
+import org.fcrepo.migration.ObjectReference;
+import org.fcrepo.migration.ObjectVersionReference;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Directly exercises the {@link ObjectReference} and {@link ObjectVersionReference}
+ * views produced by {@link ObjectAbstractionStreamingFedoraObjectHandler}.
+ *
+ * @author Claude
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ObjectAbstractionStreamingFedoraObjectHandlerTest {
+
+    @Mock
+    private ObjectInfo objectInfo;
+
+    @Mock
+    private ObjectProperties objectProperties;
+
+    private DatastreamVersion ds1;
+    private DatastreamVersion ds2;
+
+    @Before
+    public void setup() {
+        ds1 = datastreamVersion("DS1", "DS1.0", "2020-01-01T00:00:00.000Z", Instant.parse("2020-01-01T00:00:00Z"));
+        ds2 = datastreamVersion("DS2", "DS2.0", "2020-01-02T00:00:00.000Z", Instant.parse("2020-01-02T00:00:00Z"));
+    }
+
+    @Test
+    public void exercisesReferenceViews() {
+        final List<ObjectVersionReference> captured = new ArrayList<>();
+        final FedoraObjectVersionHandler versionHandler = (versions, objectInfo) -> {
+            for (final ObjectVersionReference version : versions) {
+                captured.add(version);
+
+                // ObjectReference view
+                final ObjectReference ref = version.getObject();
+                Assert.assertSame(this.objectInfo, ref.getObjectInfo());
+                Assert.assertSame(this.objectProperties, ref.getObjectProperties());
+                Assert.assertEquals(List.of("DS1", "DS2"), ref.listDatastreamIds());
+                Assert.assertEquals("DS1.0", ref.getDatastreamVersions("DS1").get(0).getVersionId());
+
+                // ObjectVersionReference view
+                Assert.assertSame(this.objectProperties, version.getObjectProperties());
+            }
+        };
+
+        final var handler = new ObjectAbstractionStreamingFedoraObjectHandler(versionHandler);
+        handler.beginObject(objectInfo);
+        handler.processObjectProperties(objectProperties);
+        handler.processDatastreamVersion(ds1);
+        handler.processDatastreamVersion(ds2);
+        handler.completeObject(objectInfo);
+
+        Assert.assertEquals(2, captured.size());
+
+        final ObjectVersionReference first = captured.get(0);
+        Assert.assertEquals("2020-01-01T00:00:00.000Z", first.getVersionDate());
+        Assert.assertEquals(0, first.getVersionIndex());
+        Assert.assertTrue(first.isFirstVersion());
+        Assert.assertFalse(first.isLastVersion());
+        Assert.assertTrue(first.wasDatastreamChanged("DS1"));
+        Assert.assertFalse(first.wasDatastreamChanged("DS2"));
+
+        final ObjectVersionReference last = captured.get(1);
+        Assert.assertEquals(1, last.getVersionIndex());
+        Assert.assertFalse(last.isFirstVersion());
+        Assert.assertTrue(last.isLastVersion());
+        Assert.assertTrue(last.wasDatastreamChanged("DS2"));
+    }
+
+    @Test
+    public void abortClearsStateForReuse() {
+        final FedoraObjectVersionHandler versionHandler = Mockito.mock(FedoraObjectVersionHandler.class);
+        final var handler = new ObjectAbstractionStreamingFedoraObjectHandler(versionHandler);
+        handler.beginObject(objectInfo);
+        handler.processDatastreamVersion(ds1);
+        handler.abortObject(objectInfo);
+
+        Mockito.verifyZeroInteractions(versionHandler);
+    }
+
+    private DatastreamVersion datastreamVersion(final String dsId, final String versionId,
+                                                final String created, final Instant createdInstant) {
+        final DatastreamInfo info = Mockito.mock(DatastreamInfo.class);
+        Mockito.lenient().when(info.getDatastreamId()).thenReturn(dsId);
+        final DatastreamVersion version = Mockito.mock(DatastreamVersion.class);
+        Mockito.lenient().when(version.getDatastreamInfo()).thenReturn(info);
+        Mockito.lenient().when(version.getVersionId()).thenReturn(versionId);
+        Mockito.lenient().when(version.getCreated()).thenReturn(created);
+        Mockito.lenient().when(version.getCreatedInstant()).thenReturn(createdInstant);
+        return version;
+    }
+}

--- a/src/test/java/org/fcrepo/migration/handlers/ObjectAbstractionStreamingFedoraObjectHandlerTest.java
+++ b/src/test/java/org/fcrepo/migration/handlers/ObjectAbstractionStreamingFedoraObjectHandlerTest.java
@@ -29,7 +29,7 @@ import org.mockito.junit.MockitoJUnitRunner;
  * Directly exercises the {@link ObjectReference} and {@link ObjectVersionReference}
  * views produced by {@link ObjectAbstractionStreamingFedoraObjectHandler}.
  *
- * @author Claude
+ * @author Dan Field
  */
 @RunWith(MockitoJUnitRunner.class)
 public class ObjectAbstractionStreamingFedoraObjectHandlerTest {

--- a/src/test/java/org/fcrepo/migration/handlers/ocfl/CountingInputStreamTest.java
+++ b/src/test/java/org/fcrepo/migration/handlers/ocfl/CountingInputStreamTest.java
@@ -24,7 +24,7 @@ import java.nio.charset.StandardCharsets;
 import org.junit.Test;
 
 /**
- * @author Claude
+ * @author Dan Field
  */
 public class CountingInputStreamTest {
 

--- a/src/test/java/org/fcrepo/migration/handlers/ocfl/CountingInputStreamTest.java
+++ b/src/test/java/org/fcrepo/migration/handlers/ocfl/CountingInputStreamTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.migration.handlers.ocfl;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+/**
+ * @author Claude
+ */
+public class CountingInputStreamTest {
+
+    @Test
+    public void readsSingleBytesToEof() throws IOException {
+        final var data = "abc".getBytes(StandardCharsets.UTF_8);
+        try (var stream = new CountingInputStream(new ByteArrayInputStream(data))) {
+            int count = 0;
+            while (stream.read() != -1) {
+                count++;
+            }
+            assertEquals(3, count);
+        }
+    }
+
+    @Test
+    public void readsByteArraysToEof() throws IOException {
+        final var data = "hello world".getBytes(StandardCharsets.UTF_8);
+        try (var stream = new CountingInputStream(new ByteArrayInputStream(data))) {
+            final var buffer = new byte[4];
+            int total = 0;
+            int read;
+            while ((read = stream.read(buffer, 0, buffer.length)) != -1) {
+                total += read;
+            }
+            assertEquals(data.length, total);
+        }
+    }
+}

--- a/src/test/java/org/fcrepo/migration/handlers/ocfl/CountingInputStreamTest.java
+++ b/src/test/java/org/fcrepo/migration/handlers/ocfl/CountingInputStreamTest.java
@@ -1,17 +1,7 @@
 /*
- * Copyright 2021 DuraSpace, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
  */
 package org.fcrepo.migration.handlers.ocfl;
 

--- a/src/test/java/org/fcrepo/migration/handlers/ocfl/OcflObjectSessionWrapperTest.java
+++ b/src/test/java/org/fcrepo/migration/handlers/ocfl/OcflObjectSessionWrapperTest.java
@@ -42,7 +42,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 /**
  * Verifies that {@link OcflObjectSessionWrapper} delegates every operation to the wrapped session.
  *
- * @author Claude
+ * @author Dan Field
  */
 @RunWith(MockitoJUnitRunner.class)
 public class OcflObjectSessionWrapperTest {

--- a/src/test/java/org/fcrepo/migration/handlers/ocfl/OcflObjectSessionWrapperTest.java
+++ b/src/test/java/org/fcrepo/migration/handlers/ocfl/OcflObjectSessionWrapperTest.java
@@ -1,17 +1,7 @@
 /*
- * Copyright 2021 DuraSpace, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
  */
 package org.fcrepo.migration.handlers.ocfl;
 

--- a/src/test/java/org/fcrepo/migration/handlers/ocfl/OcflObjectSessionWrapperTest.java
+++ b/src/test/java/org/fcrepo/migration/handlers/ocfl/OcflObjectSessionWrapperTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2021 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.migration.handlers.ocfl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.fcrepo.storage.ocfl.CommitType;
+import org.fcrepo.storage.ocfl.OcflObjectSession;
+import org.fcrepo.storage.ocfl.OcflVersionInfo;
+import org.fcrepo.storage.ocfl.ResourceContent;
+import org.fcrepo.storage.ocfl.ResourceHeaders;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Verifies that {@link OcflObjectSessionWrapper} delegates every operation to the wrapped session.
+ *
+ * @author Claude
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class OcflObjectSessionWrapperTest {
+
+    @Mock
+    private OcflObjectSession inner;
+
+    @Mock
+    private ResourceHeaders headers;
+
+    @Mock
+    private ResourceContent content;
+
+    private OcflObjectSessionWrapper wrapper;
+
+    @Before
+    public void setup() {
+        wrapper = new OcflObjectSessionWrapper(inner);
+    }
+
+    @Test
+    public void delegatesIdentifiers() {
+        when(inner.sessionId()).thenReturn("session-1");
+        when(inner.ocflObjectId()).thenReturn("info:fedora/obj");
+        assertEquals("session-1", wrapper.sessionId());
+        assertEquals("info:fedora/obj", wrapper.ocflObjectId());
+    }
+
+    @Test
+    public void delegatesWriteResourceWithContent() {
+        final InputStream content = new ByteArrayInputStream("data".getBytes(StandardCharsets.UTF_8));
+        when(inner.writeResource(org.mockito.ArgumentMatchers.eq(headers),
+                org.mockito.ArgumentMatchers.any())).thenReturn(headers);
+        assertEquals(headers, wrapper.writeResource(headers, content));
+        verify(inner).writeResource(org.mockito.ArgumentMatchers.eq(headers),
+                org.mockito.ArgumentMatchers.any(CountingInputStream.class));
+    }
+
+    @Test
+    public void delegatesWriteResourceWithNullContent() {
+        when(inner.writeResource(org.mockito.ArgumentMatchers.eq(headers),
+                org.mockito.ArgumentMatchers.isNull())).thenReturn(headers);
+        assertEquals(headers, wrapper.writeResource(headers, null));
+        verify(inner).writeResource(headers, null);
+    }
+
+    @Test
+    public void delegatesWriteHeaders() {
+        wrapper.writeHeaders(headers);
+        verify(inner).writeHeaders(headers);
+    }
+
+    @Test
+    public void delegatesDeleteOperations() {
+        wrapper.deleteContentFile(headers);
+        verify(inner).deleteContentFile(headers);
+        wrapper.deleteResource("res-1");
+        verify(inner).deleteResource("res-1");
+    }
+
+    @Test
+    public void delegatesContainsResource() {
+        when(inner.containsResource("res-1")).thenReturn(true);
+        assertEquals(true, wrapper.containsResource("res-1"));
+    }
+
+    @Test
+    public void delegatesReadHeaders() {
+        when(inner.readHeaders("res-1")).thenReturn(headers);
+        when(inner.readHeaders("res-1", "v1")).thenReturn(headers);
+        assertEquals(headers, wrapper.readHeaders("res-1"));
+        assertEquals(headers, wrapper.readHeaders("res-1", "v1"));
+    }
+
+    @Test
+    public void delegatesReadContentAndRanges() {
+        when(inner.readContent("res-1")).thenReturn(content);
+        when(inner.readContent("res-1", "v1")).thenReturn(content);
+        when(inner.readRange("res-1", "v1", 0L, 10L)).thenReturn(content);
+        when(inner.readRange("res-1", null, 0L, 10L)).thenReturn(content);
+
+        assertEquals(content, wrapper.readContent("res-1"));
+        assertEquals(content, wrapper.readContent("res-1", "v1"));
+        assertEquals(content, wrapper.readRange("res-1", "v1", 0L, 10L));
+        assertEquals(content, wrapper.readRange("res-1", 0L, 10L));
+        verify(inner).readRange("res-1", null, 0L, 10L);
+    }
+
+    @Test
+    public void delegatesListVersions() {
+        final List<OcflVersionInfo> versions = Collections.emptyList();
+        when(inner.listVersions("res-1")).thenReturn(versions);
+        assertEquals(versions, wrapper.listVersions("res-1"));
+    }
+
+    @Test
+    public void delegatesStreamResourceHeaders() {
+        final Stream<ResourceHeaders> stream = Stream.of(headers);
+        when(inner.streamResourceHeaders()).thenReturn(stream);
+        assertEquals(stream, wrapper.streamResourceHeaders());
+    }
+
+    @Test
+    public void delegatesVersioningMetadata() {
+        final var timestamp = OffsetDateTime.now();
+        wrapper.versionCreationTimestamp(timestamp);
+        verify(inner).versionCreationTimestamp(timestamp);
+        wrapper.versionAuthor("name", "address");
+        verify(inner).versionAuthor("name", "address");
+        wrapper.versionMessage("message");
+        verify(inner).versionMessage("message");
+        wrapper.invalidateCache("obj-1");
+        verify(inner).invalidateCache("obj-1");
+        wrapper.commitType(CommitType.NEW_VERSION);
+        verify(inner).commitType(CommitType.NEW_VERSION);
+    }
+
+    @Test
+    public void delegatesLifecycle() {
+        when(inner.isOpen()).thenReturn(true);
+        wrapper.commit();
+        verify(inner).commit();
+        wrapper.abort();
+        verify(inner).abort();
+        wrapper.rollback();
+        verify(inner).rollback();
+        assertEquals(true, wrapper.isOpen());
+        wrapper.close();
+        verify(inner).close();
+    }
+
+    @Test
+    public void isOpenReflectsInner() {
+        when(inner.isOpen()).thenReturn(false);
+        assertFalse(wrapper.isOpen());
+    }
+}

--- a/src/test/java/org/fcrepo/migration/handlers/ocfl/PlainOcflObjectSessionTest.java
+++ b/src/test/java/org/fcrepo/migration/handlers/ocfl/PlainOcflObjectSessionTest.java
@@ -35,10 +35,16 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -153,6 +159,138 @@ public class PlainOcflObjectSessionTest {
         session.abort();
 
         assertTrue(Files.notExists(staging.resolve(session.sessionId())));
+    }
+
+    @Test
+    public void identifiersAreExposed() {
+        final var session = newSession();
+        assertEquals(AG_ID, session.ocflObjectId());
+        assertTrue(session.isOpen());
+    }
+
+    @Test
+    public void invalidateCacheAndCloseAreSupported() {
+        final var session = newSession();
+        session.invalidateCache(AG_ID);
+        session.close();
+        assertFalse(session.isOpen());
+    }
+
+    @Test
+    public void unsupportedOperationsThrow() {
+        final var session = newSession();
+        assertThrows(UnsupportedOperationException.class, () -> session.writeHeaders(null));
+        assertThrows(UnsupportedOperationException.class, () -> session.deleteResource("x"));
+        assertThrows(UnsupportedOperationException.class, () -> session.readHeaders("x"));
+        assertThrows(UnsupportedOperationException.class, () -> session.readHeaders("x", "v1"));
+        assertThrows(UnsupportedOperationException.class, () -> session.readContent("x"));
+        assertThrows(UnsupportedOperationException.class, () -> session.readContent("x", "v1"));
+        assertThrows(UnsupportedOperationException.class, () -> session.readRange("x", "v1", 0L, 1L));
+        assertThrows(UnsupportedOperationException.class, () -> session.readRange("x", 0L, 1L));
+        assertThrows(UnsupportedOperationException.class, () -> session.listVersions("x"));
+        assertThrows(UnsupportedOperationException.class, () -> session.streamResourceHeaders());
+        assertThrows(UnsupportedOperationException.class, () -> session.commitType(null));
+        assertThrows(UnsupportedOperationException.class, session::rollback);
+    }
+
+    @Test
+    public void containsResourceReflectsRepository() {
+        final var probe = newSession();
+        assertFalse(probe.containsResource(AG_ID));
+        probe.abort();
+
+        final var session = newSession();
+        write(binary(AG_ID + "/bar", "test"), session);
+        session.commit();
+
+        assertTrue(newSession().containsResource(AG_ID));
+    }
+
+    @Test
+    public void writeAfterCommitThrows() {
+        final var session = newSession();
+        write(binary(AG_ID + "/bar", "test"), session);
+        session.commit();
+
+        assertThrows(IllegalStateException.class,
+                () -> write(binary(AG_ID + "/bar", "again"), session));
+    }
+
+    @Test
+    public void aclInteractionModelIsUnsupported() {
+        final var headers = headers(AG_ID + "/acl");
+        headers.withInteractionModel(InteractionModel.ACL.getUri());
+        final var session = newSession();
+        assertThrows(UnsupportedOperationException.class,
+                () -> session.writeResource(headers.build(), null));
+    }
+
+    @Test
+    public void missingInteractionModelThrows() {
+        final var headers = headers(AG_ID + "/none");
+        final var session = newSession();
+        assertThrows(IllegalArgumentException.class,
+                () -> session.writeResource(headers.build(), null));
+    }
+
+    @Test
+    public void versionMetadataIsPersisted() {
+        final var session = newSession();
+        session.versionAuthor("Migrator", "info:fedora/migrator");
+        session.versionMessage("initial migration");
+        write(binary(AG_ID + "/bar", "test"), session);
+        session.commit();
+
+        final var versionInfo = ocflRepo.describeVersion(ObjectVersionId.head(AG_ID)).getVersionInfo();
+        assertEquals("initial migration", versionInfo.getMessage());
+        assertEquals("Migrator", versionInfo.getUser().getName());
+    }
+
+    @Test
+    public void writeWithValidChecksumRegistersFixity() throws Exception {
+        final var dsId = "bar";
+        final var resourceId = AG_ID + "/" + dsId;
+        final var value = "checksummed";
+        final var digest = sha512Hex(value);
+
+        final var headers = headers(resourceId);
+        headers.withInteractionModel(InteractionModel.NON_RDF.getUri());
+        headers.withDigests(List.of(URI.create("urn:sha-512:" + digest)));
+        final var content = new ResourceContent(IOUtils.toInputStream(value), headers.build());
+
+        final var session = newSession();
+        write(content, session);
+        session.commit();
+
+        assertEquals(value,
+                IOUtils.toString(ocflRepo.getObject(ObjectVersionId.head(AG_ID)).getFile(dsId).getStream()));
+    }
+
+    @Test
+    public void deleteContentFileRemovesFileOnCommit() {
+        final var dsId = "bar";
+        final var writeSession = newSession();
+        write(binary(AG_ID + "/" + dsId, "test"), writeSession);
+        writeSession.commit();
+        assertTrue(ocflRepo.getObject(ObjectVersionId.head(AG_ID)).containsFile(dsId));
+
+        final var deleteHeaders = headers(AG_ID + "/" + dsId);
+        deleteHeaders.withInteractionModel(InteractionModel.NON_RDF.getUri());
+        final var deleteSession = newSession();
+        deleteSession.deleteContentFile(deleteHeaders.build());
+        deleteSession.commit();
+
+        assertFalse(ocflRepo.getObject(ObjectVersionId.head(AG_ID)).containsFile(dsId));
+    }
+
+    private static String sha512Hex(final String value) throws NoSuchAlgorithmException {
+        final var digest = MessageDigest.getInstance("SHA-512");
+        final var bytes = digest.digest(value.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        final var sb = new StringBuilder();
+        for (final byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
     }
 
     private void write(final ResourceContent content, final OcflObjectSession session) {

--- a/src/test/java/org/fcrepo/migration/metrics/PrometheusActuatorTest.java
+++ b/src/test/java/org/fcrepo/migration/metrics/PrometheusActuatorTest.java
@@ -1,17 +1,7 @@
 /*
- * Copyright 2021 DuraSpace, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
  */
 package org.fcrepo.migration.metrics;
 

--- a/src/test/java/org/fcrepo/migration/metrics/PrometheusActuatorTest.java
+++ b/src/test/java/org/fcrepo/migration/metrics/PrometheusActuatorTest.java
@@ -30,7 +30,7 @@ import io.micrometer.core.instrument.Timer;
 import org.junit.Test;
 
 /**
- * @author Claude
+ * @author Dan Field
  */
 public class PrometheusActuatorTest {
 

--- a/src/test/java/org/fcrepo/migration/metrics/PrometheusActuatorTest.java
+++ b/src/test/java/org/fcrepo/migration/metrics/PrometheusActuatorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.migration.metrics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import org.junit.Test;
+
+/**
+ * @author Claude
+ */
+public class PrometheusActuatorTest {
+
+    @Test
+    public void disabledActuatorDoesNothing() {
+        final var actuator = new PrometheusActuator(false);
+        // start/stop should be no-ops when metrics are disabled (no server was created)
+        actuator.start();
+        actuator.stop();
+    }
+
+    @Test
+    public void enabledActuatorServesScrape() throws IOException {
+        final var actuator = new PrometheusActuator(true);
+        try {
+            // Exercise both branches of the meter filter (timer and non-timer).
+            Timer.builder("test.timer").register(Metrics.globalRegistry).record(() -> { });
+            Counter.builder("test.counter").register(Metrics.globalRegistry).increment();
+
+            actuator.start();
+
+            final var url = new URL("http://localhost:8080/prometheus");
+            final var connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+            assertEquals(HttpURLConnection.HTTP_OK, connection.getResponseCode());
+
+            final String body;
+            try (InputStream is = connection.getInputStream()) {
+                body = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            }
+            assertTrue("scrape output should contain registered metrics", body.contains("jvm_"));
+        } finally {
+            actuator.stop();
+        }
+    }
+}

--- a/src/test/java/org/fcrepo/migration/pidlist/ResumePidListManagerResumeTest.java
+++ b/src/test/java/org/fcrepo/migration/pidlist/ResumePidListManagerResumeTest.java
@@ -1,0 +1,48 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ *
+ */
+package org.fcrepo.migration.pidlist;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Covers the constructor validation and the resume-state mismatch handling of
+ * {@link ResumePidListManager}.
+ *
+ * @author Claude
+ */
+public class ResumePidListManagerResumeTest {
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorRejectsNonDirectory() throws IOException {
+        final File notADir = tempDir.newFile("not-a-dir.txt");
+        new ResumePidListManager(notADir, false);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void mismatchedResumeStateThrows() throws IOException {
+        final File pidDir = tempDir.newFolder("pids");
+
+        // First run establishes a resume file at index 2 with value "pid:2".
+        final ResumePidListManager first = new ResumePidListManager(pidDir, false);
+        first.accept("pid:1");
+        first.accept("pid:2");
+
+        // Resuming and then diverging from the recorded ordering must fail.
+        final ResumePidListManager resumed = new ResumePidListManager(pidDir, false);
+        resumed.accept("pid:1");
+        resumed.accept("divergent");
+        resumed.accept("pid:3");
+    }
+}

--- a/src/test/java/org/fcrepo/migration/pidlist/ResumePidListManagerResumeTest.java
+++ b/src/test/java/org/fcrepo/migration/pidlist/ResumePidListManagerResumeTest.java
@@ -1,8 +1,7 @@
-/**
+/*
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree.
- *
  */
 package org.fcrepo.migration.pidlist;
 

--- a/src/test/java/org/fcrepo/migration/pidlist/ResumePidListManagerResumeTest.java
+++ b/src/test/java/org/fcrepo/migration/pidlist/ResumePidListManagerResumeTest.java
@@ -17,7 +17,7 @@ import org.junit.rules.TemporaryFolder;
  * Covers the constructor validation and the resume-state mismatch handling of
  * {@link ResumePidListManager}.
  *
- * @author Claude
+ * @author Dan Field
  */
 public class ResumePidListManagerResumeTest {
 

--- a/src/test/java/org/fcrepo/migration/pidlist/UserProvidedPidListManagerTest.java
+++ b/src/test/java/org/fcrepo/migration/pidlist/UserProvidedPidListManagerTest.java
@@ -68,4 +68,23 @@ public class UserProvidedPidListManagerTest {
         Assert.assertFalse("'bad' should NOT be accepted", manager.accept("bad"));
         Assert.assertFalse("'junk' should NOT be accepted", manager.accept("junk"));
     }
+
+    @Test
+    public void finishedProcessingAllPids() {
+        Assert.assertFalse("not finished before processing", manager.finishedProcessingAllPids());
+        pidList.forEach(pid -> manager.accept(pid));
+        Assert.assertTrue("finished once every pid is processed", manager.finishedProcessingAllPids());
+    }
+
+    @Test
+    public void acceptAllNeverFinishes() {
+        final UserProvidedPidListManager acceptAll = new UserProvidedPidListManager(null);
+        acceptAll.accept("pid:1");
+        Assert.assertFalse("accept-all mode has no completion state", acceptAll.finishedProcessingAllPids());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void missingFileThrows() {
+        new UserProvidedPidListManager(new File("does-not-exist-98765.txt"));
+    }
 }

--- a/src/test/java/org/fcrepo/migration/urlmappers/SelfReferencingURLMapperTest.java
+++ b/src/test/java/org/fcrepo/migration/urlmappers/SelfReferencingURLMapperTest.java
@@ -16,7 +16,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 /**
- * @author Claude
+ * @author Dan Field
  */
 @RunWith(MockitoJUnitRunner.class)
 public class SelfReferencingURLMapperTest {

--- a/src/test/java/org/fcrepo/migration/urlmappers/SelfReferencingURLMapperTest.java
+++ b/src/test/java/org/fcrepo/migration/urlmappers/SelfReferencingURLMapperTest.java
@@ -1,8 +1,7 @@
-/**
+/*
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree.
- *
  */
 package org.fcrepo.migration.urlmappers;
 

--- a/src/test/java/org/fcrepo/migration/urlmappers/SelfReferencingURLMapperTest.java
+++ b/src/test/java/org/fcrepo/migration/urlmappers/SelfReferencingURLMapperTest.java
@@ -1,0 +1,65 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ *
+ */
+package org.fcrepo.migration.urlmappers;
+
+import org.fcrepo.migration.MigrationIDMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author Claude
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SelfReferencingURLMapperTest {
+
+    private static final String SERVER = "localhost:8080";
+
+    @Mock
+    private MigrationIDMapper idMapper;
+
+    private SelfReferencingURLMapper mapper;
+
+    @Before
+    public void setup() {
+        Mockito.when(idMapper.getBaseURL()).thenReturn("http://fcrepo/rest");
+        Mockito.when(idMapper.mapDatastreamPath(Mockito.anyString(), Mockito.anyString()))
+                .thenAnswer(i -> "/" + i.getArgument(0) + "/" + i.getArgument(1));
+        mapper = new SelfReferencingURLMapper(SERVER, idMapper);
+    }
+
+    @Test
+    public void testMapsOldContentUrl() {
+        final String result = mapper.mapURL("http://localhost:8080/fedora/get/object:1/DS1");
+        Assert.assertEquals("http://fcrepo/rest/object:1/DS1", result);
+        Mockito.verify(idMapper).mapDatastreamPath("object:1", "DS1");
+    }
+
+    @Test
+    public void testMapsNewContentUrl() {
+        final String result =
+                mapper.mapURL("http://localhost:8080/fedora/objects/object:1/datastreams/DS1/content");
+        Assert.assertEquals("http://fcrepo/rest/object:1/DS1", result);
+        Mockito.verify(idMapper).mapDatastreamPath("object:1", "DS1");
+    }
+
+    @Test
+    public void testPassesThroughUnrelatedUrl() {
+        final String url = "http://example.org/some/external/resource";
+        Assert.assertEquals(url, mapper.mapURL(url));
+        Mockito.verify(idMapper, Mockito.never()).mapDatastreamPath(Mockito.anyString(), Mockito.anyString());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testThrowsOnUnhandledInternalUrl() {
+        mapper.mapURL("http://localhost:8080/fedora/objects/object:1/unexpected");
+    }
+}


### PR DESCRIPTION
**JIRA Ticket**: N/A

# What does this Pull Request do?

Enables working Codecov coverage reporting and raises measured test coverage above 90%.

While wiring up Codecov (following the fcrepo-camel workflow), I found that coverage was not actually being captured — the reported numbers would have been badly wrong. This PR fixes the capture and then adds tests to bring real coverage to **90.1% line / 90.7% instruction** (up from ~60%).

# What's new?

**Coverage capture fixes (prerequisite — without these, JaCoCo recorded almost nothing):**
* Fixed the Surefire/Failsafe `argLine` so the JaCoCo agents actually attach. `fcrepo-parent` sets a literal `<argLine>-Xms512m -Xmx1024m</argLine>`, which overrode the `argLine` property `prepare-agent` publishes, so no `.exec` data was produced. Now `@{argLine}` / `@{failsafeArgLine}` are late-substituted in.
* Capture integration-test coverage (`prepare-agent-integration`), merge the unit + IT exec data, and generate the report at the `verify` phase (it previously ran at `prepare-package`, before the ITs executed).
* Restrict the Codecov upload step to `ubuntu-latest` to avoid duplicate uploads from the OS matrix.
* Add a Codecov badge to the README.

**New/extended tests (13 new, 3 extended):**
* urlmappers: `SelfReferencingURLMapper`
* handlers: `ConsoleLoggingStreamingFedoraObjectHandler`, `ObjectAbstractionStreamingFedoraObjectHandler` reference views
* handlers.ocfl: `OcflObjectSessionWrapper` delegation, `CountingInputStream`, and additional `PlainOcflObjectSession` paths (unsupported ops, delete, versioning, checksum fixity, closed-session, invalidateCache/close)
* foxml: `NamespacePrefixMapper`, `DirectoryScanningIDResolver`, `FoxmlDirectoryDFSIterator` traversal, directory object-source file filters, `DC` edge cases
* metrics: `PrometheusActuator` (disabled + live HTTP scrape)
* migration: `Migrator` (limit / pid-filter / continue-on-error paths, printHelp) and `PicocliMigrator` `main()` + execution-exception handler
* pidlist: `ResumePidListManager` resume-state mismatch, `UserProvidedPidListManager` completion state

# How should this be tested?

* `mvn clean verify` — all 133 unit + 28 integration tests pass, Checkstyle and Javadoc are clean.
* Inspect `target/site/jacoco/index.html` (or the merged `target/jacoco-merged.exec`) and confirm line coverage ≥ 90%.
* Confirm a `target/jacoco.exec` file is now produced during the build (it was not before this change).

# Additional Notes:

* No new production dependencies; changes are limited to the build config, tests, README, and the CI workflow.
* Coverage is uploaded from both the Ubuntu and Windows matrix jobs (merged by Codecov), so the Windows-only path-encoding branches in `PlainOcflObjectSession` are covered by the Windows run. Remaining uncovered code is concentrated in `Migrator.main()`'s Spring bootstrap and some `ArchiveGroupHandler` internals.
* `PrometheusActuatorTest` binds port 8080 (as the actuator does in production), so it needs that port free on the test host.

# Interested parties
@fcrepo/committers